### PR TITLE
Run rustfmt for each PR via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,21 @@
+name: "Run CI"
+on:
+  pull_request:
+
+jobs:
+  formatting:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - name: Rustfmt Check
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --check

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,12 @@
+# Disable reordering package imports alphabetically
+reorder_imports=false
+
+# Disable the granular width settings automatically configured following max_width.
+use_small_heuristics="Off"
+
+# Maximum width of each line.
+max_width=200
+
+# Maximum width of each function call
+# It is needed as use_small_heuristics=Off.
+fn_call_width=80

--- a/omaha/src/hash_types.rs
+++ b/omaha/src/hash_types.rs
@@ -12,7 +12,6 @@ use ct_codecs::{
     Decoder
 };
 
-
 #[derive(PartialEq, Eq, Clone)]
 pub struct Sha1;
 
@@ -22,8 +21,7 @@ pub struct Sha256;
 pub trait HashAlgo {
     const HASH_NAME: &'static str;
 
-    type Output:
-        AsRef<[u8]> + AsMut<[u8]> + Default + Sized + Eq;
+    type Output: AsRef<[u8]> + AsMut<[u8]> + Default + Sized + Eq;
 }
 
 impl HashAlgo for Sha1 {
@@ -52,9 +50,7 @@ impl<T: HashAlgo> fmt::Debug for Hash<T> {
         let hash_hex = Hex::encode_to_string(self.0.as_ref())
             .map_err(|_| fmt::Error)?;
 
-        f.debug_tuple(&*tn)
-            .field(&hash_hex)
-            .finish()
+        f.debug_tuple(&*tn).field(&hash_hex).finish()
     }
 }
 

--- a/omaha/src/hash_types.rs
+++ b/omaha/src/hash_types.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::str;
 
+#[rustfmt::skip]
 use ct_codecs::{
     Error as CodecError,
 
@@ -47,6 +48,7 @@ impl<T: HashAlgo> Hash<T> {
 impl<T: HashAlgo> fmt::Debug for Hash<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let tn = format!("Hash<{}>", T::HASH_NAME);
+        #[rustfmt::skip]
         let hash_hex = Hex::encode_to_string(self.0.as_ref())
             .map_err(|_| fmt::Error)?;
 
@@ -58,6 +60,7 @@ impl<T: HashAlgo> fmt::Debug for Hash<T> {
 
 impl<T: HashAlgo> fmt::Display for Hash<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[rustfmt::skip]
         let hash_hex = Hex::encode_to_string(self.0.as_ref())
             .map_err(|_| fmt::Error)?;
 

--- a/omaha/src/lib.rs
+++ b/omaha/src/lib.rs
@@ -7,7 +7,6 @@ pub use self::types::*;
 mod uuid;
 pub use self::uuid::*;
 
-
 pub mod request;
 pub use request::Request;
 

--- a/omaha/src/request.rs
+++ b/omaha/src/request.rs
@@ -5,19 +5,18 @@ use hard_xml::XmlWrite;
 
 use crate as omaha;
 
-
 #[allow(dead_code)]
 #[derive(Debug)]
 pub enum InstallSource {
     OnDemand,
-    Scheduler
+    Scheduler,
 }
 
 impl fmt::Display for InstallSource {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             InstallSource::OnDemand => f.write_str("ondemand"),
-            InstallSource::Scheduler => f.write_str("scheduler")
+            InstallSource::Scheduler => f.write_str("scheduler"),
         }
     }
 }
@@ -32,7 +31,7 @@ pub struct Os<'a> {
     pub version: Cow<'a, str>,
 
     #[xml(attr = "sp")]
-    pub service_pack: Cow<'a, str>
+    pub service_pack: Cow<'a, str>,
 }
 
 #[derive(XmlWrite)]
@@ -64,7 +63,7 @@ pub struct App<'a> {
     pub machine_id: Cow<'a, str>,
 
     #[xml(child = "updatecheck")]
-    pub update_check: Option<AppUpdateCheck>
+    pub update_check: Option<AppUpdateCheck>,
 }
 
 #[derive(XmlWrite)]
@@ -89,5 +88,5 @@ pub struct Request<'a> {
     pub os: Os<'a>,
 
     #[xml(child = "app")]
-    pub apps: Vec<App<'a>>
+    pub apps: Vec<App<'a>>,
 }

--- a/omaha/src/response.rs
+++ b/omaha/src/response.rs
@@ -122,6 +122,7 @@ pub struct Manifest<'a> {
 }
 
 impl<'__input: 'a, 'a> hard_xml::XmlRead<'__input> for Manifest<'a> {
+    #[rustfmt::skip]
     fn from_reader(
         reader: &mut hard_xml::XmlReader<'__input>,
     ) -> hard_xml::XmlResult<Self> {
@@ -236,6 +237,7 @@ pub struct UpdateCheck<'a> {
 }
 
 impl<'__input: 'a, 'a> hard_xml::XmlRead<'__input> for UpdateCheck<'a> {
+    #[rustfmt::skip]
     fn from_reader(
         reader: &mut hard_xml::XmlReader<'__input>,
     ) -> hard_xml::XmlResult<Self> {

--- a/omaha/src/response.rs
+++ b/omaha/src/response.rs
@@ -8,7 +8,6 @@ use url::Url;
 use crate as omaha;
 use self::omaha::{Sha1, Sha256};
 
-
 // for Manifest and UpdateCheck, we've customised the XmlRead implementation (using `cargo expand`
 // and inlining) so that we can flatten the `packages`, `actions`, and `urls` container tags.
 // this lets us do `update_check.urls[n]` instead of `update_check.urls.urls[n]`.
@@ -30,7 +29,7 @@ pub struct Package<'a> {
     pub required: bool,
 
     #[xml(attr = "sha256")]
-    pub hash_sha256: Option<omaha::Hash<Sha256>>
+    pub hash_sha256: Option<omaha::Hash<Sha256>>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -38,7 +37,7 @@ pub enum ActionEvent {
     PreInstall,
     Install,
     PostInstall,
-    Update
+    Update,
 }
 
 impl fmt::Display for ActionEvent {
@@ -62,7 +61,7 @@ impl FromStr for ActionEvent {
             "postinstall" => ActionEvent::PostInstall,
             "update" => ActionEvent::Update,
 
-            _ => return Err(format!("unknown success action \"{}\"", s))
+            _ => return Err(format!("unknown success action \"{}\"", s)),
         })
     }
 }
@@ -71,7 +70,7 @@ impl FromStr for ActionEvent {
 pub enum SuccessAction {
     Default,
     ExitSilently,
-    ExitSilentlyOnLaunchCommand
+    ExitSilentlyOnLaunchCommand,
 }
 
 impl fmt::Display for SuccessAction {
@@ -93,7 +92,7 @@ impl FromStr for SuccessAction {
             "exitsilently" => SuccessAction::ExitSilently,
             "exitsilentlyonlaunchcmd" => SuccessAction::ExitSilentlyOnLaunchCommand,
 
-            _ => return Err(format!("unknown success action \"{}\"", s))
+            _ => return Err(format!("unknown success action \"{}\"", s)),
         })
     }
 }
@@ -111,7 +110,7 @@ pub struct Action {
     pub disable_payload_backoff: Option<bool>,
 
     #[xml(attr = "successaction")]
-    pub success_action: Option<SuccessAction>
+    pub success_action: Option<SuccessAction>,
 }
 
 #[derive(Debug)]
@@ -363,5 +362,5 @@ pub struct Response<'a> {
     pub protocol_version: Cow<'a, str>,
 
     #[xml(child = "app")]
-    pub apps: Vec<App<'a>>
+    pub apps: Vec<App<'a>>,
 }

--- a/omaha/src/types.rs
+++ b/omaha/src/types.rs
@@ -1,6 +1,5 @@
 use std::str;
 
-
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct FileSize(usize);

--- a/src/bin/download_test.rs
+++ b/src/bin/download_test.rs
@@ -2,7 +2,6 @@ use std::error::Error;
 
 use ue_rs::download_and_hash;
 
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let client = reqwest::Client::new();

--- a/src/bin/full_test.rs
+++ b/src/bin/full_test.rs
@@ -4,7 +4,6 @@ use std::borrow::Cow;
 use hard_xml::XmlRead;
 use url::Url;
 
-
 fn get_pkgs_to_download(resp: &omaha::Response) -> Result<Vec<(Url, omaha::Hash<omaha::Sha256>)>, Box<dyn Error>> {
     let mut to_download: Vec<(Url, omaha::Hash<_>)> = Vec::new();
 
@@ -31,9 +30,9 @@ fn get_pkgs_to_download(resp: &omaha::Response) -> Result<Vec<(Url, omaha::Hash<
             match (url, hash_sha256) {
                 (Some(Ok(url)), Some(hash)) => {
                     to_download.push((url, hash.clone()));
-                },
+                }
 
-                _ => ()
+                _ => (),
             }
         }
     }
@@ -50,9 +49,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     ////
     let parameters = ue_rs::request::Parameters {
         app_version: Cow::Borrowed("3340.0.0+nightly-20220823-2100"),
-        machine_id:  Cow::Borrowed("abce671d61774703ac7be60715220bfe"),
+        machine_id: Cow::Borrowed("abce671d61774703ac7be60715220bfe"),
 
-        track: Cow::Borrowed("stable")
+        track: Cow::Borrowed("stable"),
     };
 
     let response_text = ue_rs::request::perform(&client, parameters).await?;

--- a/src/bin/full_test.rs
+++ b/src/bin/full_test.rs
@@ -12,6 +12,7 @@ fn get_pkgs_to_download(resp: &omaha::Response) -> Result<Vec<(Url, omaha::Hash<
         let manifest = &app.update_check.manifest;
 
         for pkg in &manifest.packages {
+            #[rustfmt::skip]
             let hash_sha256 = pkg.hash_sha256
                 .as_ref()
                 .or_else(|| {
@@ -23,6 +24,7 @@ fn get_pkgs_to_download(resp: &omaha::Response) -> Result<Vec<(Url, omaha::Hash<
             // TODO: multiple URLs per package
             //       not sure if nebraska sends us more than one right now but i suppose this is
             //       for mirrors?
+            #[rustfmt::skip]
             let url = app.update_check.urls.get(0)
                 .map(|u| u.join(&pkg.name));
 

--- a/src/bin/request.rs
+++ b/src/bin/request.rs
@@ -3,16 +3,15 @@ use std::borrow::Cow;
 
 use ue_rs::request;
 
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let client = reqwest::Client::new();
 
     let parameters = request::Parameters {
         app_version: Cow::Borrowed("3340.0.0+nightly-20220823-2100"),
-        machine_id:  Cow::Borrowed("abce671d61774703ac7be60715220bfe"),
+        machine_id: Cow::Borrowed("abce671d61774703ac7be60715220bfe"),
 
-        track: Cow::Borrowed("stable")
+        track: Cow::Borrowed("stable"),
     };
 
     let response = request::perform(&client, parameters).await?;

--- a/src/bin/response.rs
+++ b/src/bin/response.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use hard_xml::XmlRead;
 use omaha;
 
+#[rustfmt::skip]
 const RESPONSE_XML: &'static str =
 r#"<?xml version="1.0" encoding="UTF-8"?>
 <response protocol="3.0" server="nebraska">
@@ -42,9 +43,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         for pkg in &manifest.packages {
             println!("    package {}:", pkg.name);
 
+            #[rustfmt::skip]
             pkg.hash.as_ref()
                 .map(|h| println!("      sha1: {}", h));
 
+            #[rustfmt::skip]
             let hash_sha256 = pkg.hash_sha256
                 .as_ref()
                 .or_else(|| {
@@ -53,6 +56,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         .map(|a| &a.sha256)
                 });
 
+            #[rustfmt::skip]
             hash_sha256
                 .map(|h| {
                     println!("      sha256: {}", h);

--- a/src/download.rs
+++ b/src/download.rs
@@ -4,17 +4,16 @@ use std::io;
 
 use sha2::{Sha256, Digest};
 
-
 pub struct DownloadResult<W: std::io::Write> {
     pub hash: omaha::Hash<omaha::Sha256>,
-    pub data: W
+    pub data: W,
 }
 
 pub async fn download_and_hash<U, W>(client: &reqwest::Client, url: U, mut data: W) -> Result<DownloadResult<W>, Box<dyn Error>>
-    where U: reqwest::IntoUrl,
-          W: io::Write
+where
+    U: reqwest::IntoUrl,
+    W: io::Write,
 {
-
     #[rustfmt::skip]
     let mut res = client.get(url)
         .send()
@@ -32,9 +31,12 @@ pub async fn download_and_hash<U, W>(client: &reqwest::Client, url: U, mut data:
         data.write_all(&chunk)?;
 
         // TODO: better way to report progress?
-        print!("\rread {}/{} ({:3}%)",
-            bytes_read, bytes_to_read,
-            ((bytes_read as f32 / bytes_to_read as f32) * 100.0f32).floor());
+        print!(
+            "\rread {}/{} ({:3}%)",
+            bytes_read,
+            bytes_to_read,
+            ((bytes_read as f32 / bytes_to_read as f32) * 100.0f32).floor()
+        );
         io::stdout().flush()?;
     }
 
@@ -43,6 +45,6 @@ pub async fn download_and_hash<U, W>(client: &reqwest::Client, url: U, mut data:
 
     Ok(DownloadResult {
         hash: omaha::Hash::from_bytes(hasher.finalize().into()),
-        data
+        data,
     })
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -15,6 +15,7 @@ pub async fn download_and_hash<U, W>(client: &reqwest::Client, url: U, mut data:
           W: io::Write
 {
 
+    #[rustfmt::skip]
     let mut res = client.get(url)
         .send()
         .await?;

--- a/src/request.rs
+++ b/src/request.rs
@@ -46,11 +46,13 @@ pub async fn perform<'a>(client: &reqwest::Client, parameters: Parameters<'a>) -
             os: omaha::request::Os {
                 platform: Cow::Borrowed(OS_PLATFORM),
                 version: Cow::Borrowed(OS_VERSION),
+                #[rustfmt::skip]
                 service_pack: Cow::Owned(
                     format!("{}_{}", parameters.app_version, "x86_64")
                 )
             },
 
+            #[rustfmt::skip]
             apps: vec![
                 omaha::request::App {
                     id: APP_ID,
@@ -76,6 +78,7 @@ pub async fn perform<'a>(client: &reqwest::Client, parameters: Parameters<'a>) -
     println!("request body:\n\t{}", req_body);
     println!();
 
+    #[rustfmt::skip]
     let resp = client.post(UPDATE_URL)
         .body(req_body)
         .send()

--- a/src/request.rs
+++ b/src/request.rs
@@ -4,7 +4,6 @@ use std::borrow::Cow;
 use hard_xml::XmlWrite;
 use omaha;
 
-
 //
 // SERVER=https://public.update.flatcar-linux.net/v1/update/
 // GROUP=
@@ -23,7 +22,6 @@ const OS_PLATFORM: &'static str = "CoreOS";
 const OS_VERSION: &'static str = "Chateau";
 
 const APP_ID: omaha::Uuid = omaha::uuid!("{e96281a6-d1af-4bde-9a0a-97b76e56dc57}");
-
 
 pub struct Parameters<'a> {
     pub app_version: Cow<'a, str>,
@@ -49,7 +47,7 @@ pub async fn perform<'a>(client: &reqwest::Client, parameters: Parameters<'a>) -
                 #[rustfmt::skip]
                 service_pack: Cow::Owned(
                     format!("{}_{}", parameters.app_version, "x86_64")
-                )
+                ),
             },
 
             #[rustfmt::skip]
@@ -68,7 +66,7 @@ pub async fn perform<'a>(client: &reqwest::Client, parameters: Parameters<'a>) -
 
                     update_check: Some(omaha::request::AppUpdateCheck)
                 }
-            ]
+            ],
         };
 
         r.to_string()?


### PR DESCRIPTION
Run CI workflow for each pull request. At the moment it only runs `cargo fmt --all --check`.

Add `.rustfmt.toml` to configure rustfmt per project.
Note, it is unfortunately not possible to set `trailing_comma` option, because that is only available in Nightly toolchains.
See also the [doc](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#trailing_comma).

Disable `rustfmt` check in case of method calls that spread across multiple lines, which we would like to keep as-is, even if `rustfmt` does not provide a way to disable or configure the changes.

With disabling rustfmt checks, we are now able to run rustfmt with the following `.rustfmt.toml`.

```
max_width=200
fn_call_width=80
reorder_imports=false
use_small_heuristics="Off"
```

Fixes https://github.com/flatcar/Flatcar/issues/1026.

## Testing done

Done via my fork.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
