### PR TITLE
Make CI build and run unit tests, add workspace

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,8 @@ on:
   pull_request:
 
 jobs:
-  formatting:
-    name: cargo fmt
+  build-test:
+    name: Build and test ue-rs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -19,3 +19,13 @@ jobs:
         with:
           command: fmt
           args: --all --check
+      - name: Build ue-rs
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --workspace
+      - name: Run unit tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,9 @@ url = "2"
 
 [dependencies.omaha]
 path = "omaha"
+
+[workspace]
+
+members = [
+    "omaha",
+]

--- a/omaha/src/types.rs
+++ b/omaha/src/types.rs
@@ -24,9 +24,14 @@ impl str::FromStr for FileSize {
     }
 }
 
-#[test]
-fn test_from_bytes() {
-    const TEST_SIZE: usize = 1048576_usize;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    assert_eq!(FileSize::from_bytes(TEST_SIZE).bytes(), TEST_SIZE);
+    #[test]
+    fn test_from_bytes() {
+        const TEST_SIZE: usize = 1048576_usize;
+
+        assert_eq!(FileSize::from_bytes(TEST_SIZE).bytes(), TEST_SIZE);
+    }
 }

--- a/omaha/src/uuid.rs
+++ b/omaha/src/uuid.rs
@@ -44,21 +44,18 @@ macro_rules! uuid {
     }};
 }
 
-#[test]
-fn test_from_uuid() {
-    const TEST_UUID: &str = "67e55044-10b1-426f-9247-bb680e5fe0c8";
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let testid_from_uuid = Uuid::from_uuid(
-        WrappedUuid::parse_str(TEST_UUID)
-            .ok()
-            .unwrap(),
-    );
+    #[test]
+    fn test_from_uuid() {
+        const TEST_UUID: &str = "67e55044-10b1-426f-9247-bb680e5fe0c8";
 
-    let testid_from = Uuid::from(
-        WrappedUuid::parse_str(TEST_UUID)
-            .ok()
-            .unwrap(),
-    );
+        let testid_from_uuid = Uuid::from_uuid(WrappedUuid::parse_str(TEST_UUID).ok().unwrap());
 
-    assert_eq!(testid_from_uuid.to_string(), testid_from.to_string());
+        let testid_from = Uuid::from(WrappedUuid::parse_str(TEST_UUID).ok().unwrap());
+
+        assert_eq!(testid_from_uuid.to_string(), testid_from.to_string());
+    }
 }


### PR DESCRIPTION
Add omaha to the list of workspaces, to be able to build and test both `src` and `omaha` by a single cargo command, like `cargo build --workspace` or `cargo test --workspace`.

Define tests module, and add all unit tests into the module, to avoid building unit tests when running cargo build.

In Github Actions, run `cargo build --workspace` and `cargo test --workspace`.