### PR TITLE
update_crau: parse signature header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,12 +498,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "memchr"
@@ -1252,6 +1249,7 @@ dependencies = [
 name = "update-format-crau"
 version = "0.1.0"
 dependencies = [
+ "log",
  "protobuf",
 ]
 

--- a/update-format-crau/Cargo.toml
+++ b/update-format-crau/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = "0.4.19"
 protobuf = "3"

--- a/update-format-crau/src/bin/test.rs
+++ b/update-format-crau/src/bin/test.rs
@@ -1,13 +1,19 @@
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::error::Error;
 use std::fs;
+use std::fs::File;
+use log::debug;
 
 use protobuf::Message;
-
+use proto::signatures::Signature;
 use update_format_crau::proto;
+
+//use ue_rs::verify_sig;
 
 const DELTA_UPDATE_HEADER_SIZE: u64 = 4 + 8 + 8;
 const DELTA_UPDATE_FILE_MAGIC: &[u8] = b"CrAU";
+
+const PUBKEY_FILE: &str = "../src/testdata/public_key_test_pkcs8.pem";
 
 #[derive(Debug)]
 struct DeltaUpdateFileHeader {
@@ -23,7 +29,8 @@ impl DeltaUpdateFileHeader {
     }
 }
 
-fn read_delta_update_header(f: &mut dyn Read) -> Result<DeltaUpdateFileHeader, Box<dyn Error>> {
+// Read delta update header from the given file, return DeltaUpdateFileHeader.
+fn read_delta_update_header(mut f: &File) -> Result<DeltaUpdateFileHeader, Box<dyn Error>> {
     let mut header = DeltaUpdateFileHeader {
         magic: [0; 4],
         file_format_version: 0,
@@ -48,12 +55,9 @@ fn read_delta_update_header(f: &mut dyn Read) -> Result<DeltaUpdateFileHeader, B
     Ok(header)
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    let path = std::env::args().nth(1).expect("missing path (second argument)");
-
-    let mut f = fs::File::open(path)?;
-    let header = read_delta_update_header(&mut f)?;
-
+// Take a file stream and DeltaUpdateFileHeader,
+// return a bytes slice of the actual signature data as well as its length.
+fn get_signatures_bytes<'a>(mut f: &'a File, header: &'a DeltaUpdateFileHeader) -> Result<Box<[u8]>, Box<dyn Error>> {
     let manifest_bytes = {
         let mut buf = vec![0u8; header.manifest_size as usize];
         f.read_exact(&mut buf)?;
@@ -79,12 +83,80 @@ fn main() -> Result<(), Box<dyn Error>> {
         _ => None,
     };
 
-    let signatures = match signatures_bytes {
-        Some(ref bytes) => Some(proto::Signatures::parse_from_bytes(bytes)?),
-        None => None,
+    Ok(signatures_bytes.unwrap())
+}
+
+#[rustfmt::skip]
+// parse_signature_data takes a bytes slice for signature and public key file path.
+// Return only actual data, without version and special fields.
+fn parse_signature_data(sigbytes: &[u8], pubkeyfile: &str) -> Option<Box<[u8]>> {
+    // Signatures has a container of the fields, i.e. version, data, and
+    // special fields.
+    let sigmessage = match proto::Signatures::parse_from_bytes(sigbytes) {
+        Ok(data) => data,
+        _ => return None,
     };
 
-    println!("{:?}", signatures);
+    // sigmessages.signatures[] has a single element in case of dev update payloads,
+    // while it could have multiple elements in case of production update payloads.
+    // For now we assume only dev update payloads are supported.
+    // Return the first valid signature, iterate into the next slot if invalid.
+    sigmessage.signatures.iter()
+        .find_map(|sig|
+            verify_sig_pubkey(sig, pubkeyfile)
+            .map(Vec::into_boxed_slice))
+}
+
+// Verify signature with public key
+fn verify_sig_pubkey(sig: &Signature, pubkeyfile: &str) -> Option<Vec<u8>> {
+    // The signature version is actually a numeration of the present signatures,
+    // with the index starting at 2 if only one signature is present.
+    // The Flatcar dev payload has only one signature but
+    // the production payload has two from which only one is valid.
+    // So, we see only "version 2" for dev payloads , and "version 1" and "version 2"
+    // in case of production update payloads. However, we do not explicitly check
+    // for a signature version, as the number could differ in some cases.
+    debug!("supported signature version: {:?}", sig.version());
+    let sigvec = match &sig.data {
+        Some(sigdata) => Some(sigdata),
+        _ => None,
+    };
+
+    debug!("data: {:?}", sig.data());
+    debug!("special_fields: {:?}", sig.special_fields());
+
+    // TODO: verify signature with pubkey
+    //    _ = verify_sig::verify_rsa_pkcs(testdata, sig.data(), get_public_key_pkcs_pem(pubkeyfile, KeyTypePkcs8));
+    _ = pubkeyfile;
+
+    sigvec.cloned()
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // TODO: parse args using a decent command-line parameter framework
+    let srcpath = std::env::args().nth(1).expect("missing source payload path (second argument)");
+    let sigpath = std::env::args().nth(2).expect("missing destination signature path (third argument)");
+
+    // Read update payload from srcpath, read delta update header from the payload.
+    let upfile = fs::File::open(srcpath.clone())?;
+    let header = read_delta_update_header(&upfile)?;
+
+    // Extract signature from header.
+    let sigbytes = get_signatures_bytes(&upfile, &header)?;
+
+    // Parse signature data from the signature containing data, version, special fields.
+    let sigdata = match parse_signature_data(&sigbytes, PUBKEY_FILE) {
+        Some(data) => Box::leak(data),
+        _ => return Err("unable to parse signature data".into()),
+    };
+
+    println!("Parsed signature data from file {:?}", srcpath);
+
+    // Store signature into a file.
+    let mut sigfile = fs::File::create(sigpath.clone())?;
+    let _ = sigfile.write_all(sigdata);
+
+    println!("Wrote signature data into file {:?}", sigpath);
 
     Ok(())
 }


### PR DESCRIPTION
Parse signatures header, check for signature versions.

Fixes https://github.com/flatcar/Flatcar/issues/1025