### PR TITLE
.github: run CI also when trunk branch is pushed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,11 @@
 name: "Run CI"
 on:
+  push:
+    branches:
+      - trunk
   pull_request:
+    branches:
+      - trunk
 
 jobs:
   build-test:


### PR DESCRIPTION
Run CI not only for a new pull request, but also when trunk branch is pushed.