### PR TITLE
Fix signature verification, check_download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libm"
@@ -593,9 +614,9 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "log"
@@ -909,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -1013,9 +1034,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "ffb93593068e9babdad10e4fce47dc9b3ac25315a72a59766ffd9e9a71996a04"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -1207,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1357,6 +1378,7 @@ name = "ue-rs"
 version = "0.1.0"
 dependencies = [
  "argh",
+ "bzip2",
  "env_logger",
  "globset",
  "hard-xml",
@@ -1365,6 +1387,7 @@ dependencies = [
  "protobuf",
  "reqwest",
  "sha2",
+ "tempfile",
  "tokio",
  "update-format-crau",
  "url",
@@ -1396,6 +1419,7 @@ dependencies = [
 name = "update-format-crau"
 version = "0.1.0"
 dependencies = [
+ "bzip2",
  "log",
  "protobuf",
  "rsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ log = "0.4"
 argh = "0.1"
 globset = "0.4"
 protobuf = "3.2.0"
+bzip2 = "0.4.4"
+tempfile = "3.8.1"
 
 [dependencies.hard-xml]
 path = "vendor/hard-xml"

--- a/omaha/src/hash_types.rs
+++ b/omaha/src/hash_types.rs
@@ -72,6 +72,14 @@ impl<T: HashAlgo> str::FromStr for Hash<T> {
     }
 }
 
+impl<T: HashAlgo> Into<Vec<u8>> for Hash<T> {
+    fn into(self) -> Vec<u8> {
+        let mut vec = Vec::new();
+        vec.append(&mut self.0.as_ref().to_vec());
+        vec
+    }
+}
+
 impl<T: HashAlgo> Hash<T> {
     #[inline]
     fn decode<D: Decoder>(hash: &str) -> Result<Self, CodecError> {

--- a/src/bin/download_sysext.rs
+++ b/src/bin/download_sysext.rs
@@ -52,6 +52,13 @@ impl<'a> Package<'a> {
     #[rustfmt::skip]
     fn check_download(&mut self, in_dir: &Path) -> Result<(), Box<dyn Error>> {
         let path = in_dir.join(&*self.name);
+
+        if !path.exists() {
+            // skip checking for existing downloads
+            info!("{} does not exist, skipping existing downloads.", path.display());
+            return Ok(());
+        }
+
         let md = fs::metadata(&path)?;
 
         let size_on_disk = md.len() as usize;

--- a/update-format-crau/Cargo.toml
+++ b/update-format-crau/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bzip2 = "0.4.4"
 log = "0.4.19"
 protobuf = "3"
 rsa = { version = "0.9.2", features = ["sha2"] }

--- a/update-format-crau/src/delta_update.rs
+++ b/update-format-crau/src/delta_update.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Seek, SeekFrom};
 use std::error::Error;
 use std::fs::File;
-use log::debug;
+use log::{error, debug};
 
 use protobuf::Message;
 
@@ -125,8 +125,14 @@ pub fn verify_sig_pubkey(testdata: &[u8], sig: &Signature, pubkeyfile: &str) -> 
     debug!("special_fields: {:?}", sig.special_fields());
 
     // verify signature with pubkey
-    _ = verify_sig::verify_rsa_pkcs(testdata, sig.data(), get_public_key_pkcs_pem(pubkeyfile, KeyTypePkcs8));
-    _ = pubkeyfile;
+    let res_verify = verify_sig::verify_rsa_pkcs(testdata, sig.data(), get_public_key_pkcs_pem(pubkeyfile, KeyTypePkcs8));
+    match res_verify {
+        Ok(res_verify) => res_verify,
+        Err(err) => {
+            error!("verify_rsa_pkcs signature ({}) failed with {}", sig, err);
+            return None;
+        }
+    };
 
     sigvec.cloned()
 }

--- a/update-format-crau/src/delta_update.rs
+++ b/update-format-crau/src/delta_update.rs
@@ -1,7 +1,10 @@
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{BufReader, Read, Seek, SeekFrom, Write};
 use std::error::Error;
+use std::fs;
 use std::fs::File;
+use std::path::Path;
 use log::{error, debug};
+use bzip2::read::BzDecoder;
 
 use protobuf::Message;
 
@@ -29,7 +32,7 @@ impl DeltaUpdateFileHeader {
 }
 
 // Read delta update header from the given file, return DeltaUpdateFileHeader.
-pub fn read_delta_update_header(mut f: &File) -> Result<DeltaUpdateFileHeader, Box<dyn Error>> {
+pub fn read_delta_update_header(f: &mut BufReader<File>) -> Result<DeltaUpdateFileHeader, Box<dyn Error>> {
     let mut header = DeltaUpdateFileHeader {
         magic: [0; 4],
         file_format_version: 0,
@@ -54,17 +57,23 @@ pub fn read_delta_update_header(mut f: &File) -> Result<DeltaUpdateFileHeader, B
     Ok(header)
 }
 
-// Take a file stream and DeltaUpdateFileHeader,
-// return a bytes slice of the actual signature data as well as its length.
-pub fn get_signatures_bytes<'a>(mut f: &'a File, header: &'a DeltaUpdateFileHeader) -> Result<Box<[u8]>, Box<dyn Error>> {
+// Take a buffer stream and DeltaUpdateFileHeader,
+// return DeltaArchiveManifest that contains manifest.
+pub fn get_manifest_bytes(f: &mut BufReader<File>, header: &DeltaUpdateFileHeader) -> Result<proto::DeltaArchiveManifest, Box<dyn Error>> {
     let manifest_bytes = {
         let mut buf = vec![0u8; header.manifest_size as usize];
         f.read_exact(&mut buf)?;
         buf.into_boxed_slice()
     };
 
-    let manifest = proto::DeltaArchiveManifest::parse_from_bytes(&manifest_bytes)?;
+    let delta_archive_manifest = proto::DeltaArchiveManifest::parse_from_bytes(&manifest_bytes)?;
 
+    Ok(delta_archive_manifest)
+}
+
+// Take a buffer stream and DeltaUpdateFileHeader,
+// return a bytes slice of the actual signature data as well as its length.
+pub fn get_signatures_bytes<'a>(f: &'a mut BufReader<File>, header: &'a DeltaUpdateFileHeader, manifest: &mut proto::DeltaArchiveManifest) -> Result<Box<[u8]>, Box<dyn Error>> {
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     // !!! signature offsets are from the END of the manifest !!!
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -85,10 +94,58 @@ pub fn get_signatures_bytes<'a>(mut f: &'a File, header: &'a DeltaUpdateFileHead
     Ok(signatures_bytes.unwrap())
 }
 
+// Return data length, including header and manifest.
+pub fn get_header_data_length(header: &DeltaUpdateFileHeader, manifest: &proto::DeltaArchiveManifest) -> usize {
+    // Read from the beginning of the stream, which means the whole buffer including
+    // delta update header as well as manifest. That is because data that must be verified
+    // with signatures start from the beginning.
+    //
+    // Payload data structure:
+    //  | header | manifest | data blobs | signatures |
+
+    header.translate_offset(manifest.signatures_offset.unwrap()) as usize
+}
+
+// Take a buffer reader, delta file header, manifest as input.
+// Return path to data blobs, without header, manifest, or signatures.
+pub fn get_data_blobs<'a>(f: &'a mut BufReader<File>, header: &'a DeltaUpdateFileHeader, manifest: &proto::DeltaArchiveManifest, tmppath: &Path) -> Result<File, Box<dyn Error>> {
+    fs::create_dir_all(tmppath.parent().unwrap())?;
+    let mut outfile = File::create(tmppath)?;
+
+    // Read from the beginning of header, which means buffer including only data blobs.
+    // It means it is necessary to call header.translate_offset(), in contrast to
+    // get_header_data_length.
+    // Iterate each partition_operations to get data offset and data length.
+    for pop in &manifest.partition_operations {
+        let data_offset = pop.data_offset.unwrap();
+        let data_length = pop.data_length.unwrap();
+
+        let mut partdata = vec![0u8; data_length as usize];
+
+        f.seek(SeekFrom::Start(header.translate_offset(data_offset.into())))?;
+        f.read_exact(&mut partdata)?;
+
+        // In case of bzip2-compressed chunks, extract.
+        if pop.type_.unwrap() == proto::install_operation::Type::REPLACE_BZ.into() {
+            let mut bzdecoder = BzDecoder::new(&partdata[..]);
+            let mut partdata_unpacked = Vec::new();
+            bzdecoder.read_to_end(&mut partdata_unpacked)?;
+
+            outfile.write_all(&partdata_unpacked)?;
+        } else {
+            outfile.write_all(&partdata)?;
+        }
+        outfile.flush()?;
+    }
+
+    Ok(outfile)
+}
+
 #[rustfmt::skip]
-// parse_signature_data takes a bytes slice for signature and public key file path.
-// Return only actual data, without version and special fields.
-pub fn parse_signature_data(testdata: &[u8], sigbytes: &[u8], pubkeyfile: &str) -> Option<Box<[u8]>> {
+// parse_signature_data takes bytes slices for signature and digest of data blobs,
+// and path to public key, to parse and verify the signature.
+// Return only actual signature data, without version and special fields.
+pub fn parse_signature_data(sigbytes: &[u8], digest: &[u8], pubkeyfile: &str) -> Option<Box<[u8]>> {
     // Signatures has a container of the fields, i.e. version, data, and
     // special fields.
     let sigmessage = match proto::Signatures::parse_from_bytes(sigbytes) {
@@ -102,12 +159,13 @@ pub fn parse_signature_data(testdata: &[u8], sigbytes: &[u8], pubkeyfile: &str) 
     // Return the first valid signature, iterate into the next slot if invalid.
     sigmessage.signatures.iter()
         .find_map(|sig|
-            verify_sig_pubkey(testdata, sig, pubkeyfile)
+            verify_sig_pubkey(digest, sig, pubkeyfile)
             .map(Vec::into_boxed_slice))
 }
 
-// Verify signature with public key
-pub fn verify_sig_pubkey(testdata: &[u8], sig: &Signature, pubkeyfile: &str) -> Option<Vec<u8>> {
+// verify_sig_pubkey verifies signature with the given digest and the public key.
+// Return the verified signature data.
+pub fn verify_sig_pubkey(digest: &[u8], sig: &Signature, pubkeyfile: &str) -> Option<Vec<u8>> {
     // The signature version is actually a numeration of the present signatures,
     // with the index starting at 2 if only one signature is present.
     // The Flatcar dev payload has only one signature but
@@ -121,11 +179,12 @@ pub fn verify_sig_pubkey(testdata: &[u8], sig: &Signature, pubkeyfile: &str) -> 
         _ => None,
     };
 
+    debug!("digest: {:?}", digest);
     debug!("data: {:?}", sig.data());
     debug!("special_fields: {:?}", sig.special_fields());
 
     // verify signature with pubkey
-    let res_verify = verify_sig::verify_rsa_pkcs(testdata, sig.data(), get_public_key_pkcs_pem(pubkeyfile, KeyTypePkcs8));
+    let res_verify = verify_sig::verify_rsa_pkcs_prehash(&digest, sig.data(), get_public_key_pkcs_pem(pubkeyfile, KeyTypePkcs8));
     match res_verify {
         Ok(res_verify) => res_verify,
         Err(err) => {


### PR DESCRIPTION
In update-format-crau, we should check error from `verify_rsa_pkcs` to handle errors correctly.

Fix bugs when reading from File to buffer. We need to first create a BufReader for reading from the buffer, pass that into parsing functions. That would make the code much easier to maintain, instead of passing File itself. Then we can read data without having to first open the file and track read positions.

We need to introduce get_header_data() to read header and data, setting the begining of the stream including the whole data including delta update header as well as manifest. Doing that, signature verification works well.

Also introduce get_data_blob() to read only data without header, manifest.

We need to skip checking for existing downloads, if the file does not exist. Otherwise, check_download will simply fail in the beginning, due to missing files.