### PR TITLE
migrate error handling to anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "argh"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +751,7 @@ dependencies = [
 name = "omaha"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "ct-codecs",
  "hard-xml",
  "url",
@@ -1377,6 +1384,7 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 name = "ue-rs"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "argh",
  "bzip2",
  "env_logger",
@@ -1419,6 +1427,7 @@ dependencies = [
 name = "update-format-crau"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bzip2",
  "log",
  "protobuf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,19 +6,19 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = "0.11"
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
-uuid = "1.2"
-sha2 = "0.10"
-url = "2"
-
-env_logger = "0.10"
-log = "0.4"
+anyhow = "1.0.75"
 argh = "0.1"
-globset = "0.4"
-protobuf = "3.2.0"
 bzip2 = "0.4.4"
+env_logger = "0.10"
+globset = "0.4"
+log = "0.4"
+protobuf = "3.2.0"
+reqwest = "0.11"
+sha2 = "0.10"
 tempfile = "3.8.1"
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
+url = "2"
+uuid = "1.2"
 
 [dependencies.hard-xml]
 path = "vendor/hard-xml"

--- a/examples/request.rs
+++ b/examples/request.rs
@@ -1,20 +1,28 @@
 use std::error::Error;
 use std::borrow::Cow;
 
+use anyhow::Context;
+
 use ue_rs::request;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let client = reqwest::Client::new();
 
-    let parameters = request::Parameters {
-        app_version: Cow::Borrowed("3340.0.0+nightly-20220823-2100"),
-        machine_id: Cow::Borrowed("abce671d61774703ac7be60715220bfe"),
+    const APP_VERSION_DEFAULT: &str = "3340.0.0+nightly-20220823-2100";
+    const MACHINE_ID_DEFAULT: &str = "abce671d61774703ac7be60715220bfe";
+    const TRACK_DEFAULT: &str = "stable";
 
-        track: Cow::Borrowed("stable"),
+    let parameters = request::Parameters {
+        app_version: Cow::Borrowed(APP_VERSION_DEFAULT),
+        machine_id: Cow::Borrowed(MACHINE_ID_DEFAULT),
+
+        track: Cow::Borrowed(TRACK_DEFAULT),
     };
 
-    let response = request::perform(&client, parameters).await?;
+    let response = request::perform(&client, parameters).await.context(format!(
+        "perform({APP_VERSION_DEFAULT}, {MACHINE_ID_DEFAULT}, {TRACK_DEFAULT}) failed"
+    ))?;
 
     println!("response:\n\t{:#?}", response);
 

--- a/examples/response.rs
+++ b/examples/response.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 
+use anyhow::Context;
 use hard_xml::XmlRead;
 use omaha;
 
@@ -29,7 +30,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("{}", RESPONSE_XML);
     println!();
 
-    let resp = omaha::Response::from_str(RESPONSE_XML)?;
+    let resp = omaha::Response::from_str(RESPONSE_XML).context("failed to create response")?;
 
     println!("{:#?}", resp);
     println!();
@@ -66,7 +67,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             println!("      urls:");
 
             for url in &app.update_check.urls {
-                println!("        {}", url.join(&pkg.name)?);
+                println!(
+                    "        {}",
+                    url.join(&pkg.name).context(format!("failed to join URL with {:?}", pkg.name))?
+                );
             }
 
             println!();

--- a/omaha/Cargo.toml
+++ b/omaha/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 uuid = "1.2"
 ct-codecs = "1"
 url = "2"
+anyhow = "1.0.75"
 
 [dependencies.hard-xml]
 path = "../vendor/hard-xml"

--- a/omaha/src/hash_types.rs
+++ b/omaha/src/hash_types.rs
@@ -1,10 +1,10 @@
 use std::fmt;
 use std::str;
 
+use anyhow::{Error as CodecError, anyhow};
+
 #[rustfmt::skip]
 use ct_codecs::{
-    Error as CodecError,
-
     Base64,
     Hex,
 
@@ -82,9 +82,9 @@ impl<T: HashAlgo> Into<Vec<u8>> for Hash<T> {
 
 impl<T: HashAlgo> Hash<T> {
     #[inline]
-    fn decode<D: Decoder>(hash: &str) -> Result<Self, CodecError> {
+    fn decode<D: Decoder>(hash: &str) -> anyhow::Result<Self, CodecError> {
         let mut digest = T::Output::default();
-        D::decode(digest.as_mut(), hash, None)?;
+        D::decode(digest.as_mut(), hash, None).map_err(|_| anyhow!("decode ({}) failed", hash))?;
         Ok(Self(digest))
     }
 

--- a/omaha/src/response.rs
+++ b/omaha/src/response.rs
@@ -11,10 +11,10 @@ use self::omaha::{Sha1, Sha256};
 mod sha256_hex {
     use crate as omaha;
     use self::omaha::Sha256;
-    use ct_codecs::Error;
+    use anyhow::Error as CodecError;
 
     #[inline]
-    pub(crate) fn from_str(s: &str) -> Result<omaha::Hash<Sha256>, Error> {
+    pub(crate) fn from_str(s: &str) -> Result<omaha::Hash<Sha256>, CodecError> {
         <omaha::Hash<Sha256>>::from_hex(s)
     }
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use anyhow::{Context, Result, bail};
 use std::io::Write;
 use std::io;
 use log::warn;
@@ -12,15 +12,18 @@ pub struct DownloadResult<W: std::io::Write> {
     pub data: W,
 }
 
-pub async fn download_and_hash<U, W>(client: &reqwest::Client, url: U, mut data: W) -> Result<DownloadResult<W>, Box<dyn Error>>
+pub async fn download_and_hash<U, W>(client: &reqwest::Client, url: U, mut data: W) -> Result<DownloadResult<W>>
 where
-    U: reqwest::IntoUrl,
+    U: reqwest::IntoUrl + Clone,
     W: io::Write,
 {
+    let client_url = url.clone();
+
     #[rustfmt::skip]
     let mut res = client.get(url)
         .send()
-        .await?;
+        .await
+        .context(format!("client get and send({:?}) failed", client_url.as_str()))?;
 
     // Return immediately on download failure on the client side.
     let status = res.status();
@@ -33,9 +36,9 @@ where
     if !status.is_success() {
         match status {
             StatusCode::FORBIDDEN | StatusCode::NOT_FOUND => {
-                return Err(format!("cannnot fetch remotely with status code {:?}", status).into());
+                bail!("cannnot fetch remotely with status code {:?}", status);
             }
-            _ => return Err(format!("general failure with status code {:?}", status).into()),
+            _ => bail!("general failure with status code {:?}", status),
         }
     }
 
@@ -44,11 +47,11 @@ where
     let mut bytes_read = 0usize;
     let bytes_to_read = res.content_length().unwrap_or(u64::MAX) as usize;
 
-    while let Some(chunk) = res.chunk().await? {
+    while let Some(chunk) = res.chunk().await.context("failed to get response chunk")? {
         bytes_read += chunk.len();
 
         hasher.update(&chunk);
-        data.write_all(&chunk)?;
+        data.write_all(&chunk).context("failed to write_all chunk")?;
 
         // TODO: better way to report progress?
         print!(
@@ -57,10 +60,10 @@ where
             bytes_to_read,
             ((bytes_read as f32 / bytes_to_read as f32) * 100.0f32).floor()
         );
-        io::stdout().flush()?;
+        io::stdout().flush().context("failed to flush stdout")?;
     }
 
-    data.flush()?;
+    data.flush().context("failed to flush data")?;
     println!();
 
     Ok(DownloadResult {

--- a/test/crau_verify.rs
+++ b/test/crau_verify.rs
@@ -8,6 +8,7 @@ use tempfile;
 
 use update_format_crau::{delta_update, proto};
 
+use anyhow::{Context, Result};
 use argh::FromArgs;
 
 const PUBKEY_FILE: &str = "../src/testdata/public_key_test_pkcs8.pem";
@@ -24,13 +25,13 @@ struct Args {
     sig_path: String,
 }
 
-fn hash_on_disk(path: &Path) -> Result<omaha::Hash<omaha::Sha256>, Box<dyn Error>> {
+fn hash_on_disk(path: &Path) -> Result<omaha::Hash<omaha::Sha256>> {
     use sha2::{Sha256, Digest};
 
-    let mut file = File::open(path)?;
+    let mut file = File::open(path).context(format!("failed to open path({:?})", path.display()))?;
     let mut hasher = Sha256::new();
 
-    io::copy(&mut file, &mut hasher)?;
+    io::copy(&mut file, &mut hasher).context(format!("failed to copy data path ({:?})", path.display()))?;
 
     Ok(omaha::Hash::from_bytes(hasher.finalize().into()))
 }

--- a/update-format-crau/Cargo.toml
+++ b/update-format-crau/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.75"
 bzip2 = "0.4.4"
 log = "0.4.19"
 protobuf = "3"

--- a/update-format-crau/src/verify_sig.rs
+++ b/update-format-crau/src/verify_sig.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Result, bail};
 use rsa::{RsaPrivateKey, RsaPublicKey};
 use rsa::pkcs1::{DecodeRsaPrivateKey, DecodeRsaPublicKey};
 use rsa::pkcs8::{DecodePrivateKey, DecodePublicKey};
@@ -6,7 +7,6 @@ use rsa::signature::{SignatureEncoding, Signer, Verifier};
 use rsa::signature::hazmat::PrehashVerifier;
 use rsa::sha2::Sha256;
 use std::{fs, str};
-use std::error::Error;
 
 #[derive(Debug)]
 pub enum KeyType {
@@ -20,7 +20,7 @@ pub enum KeyType {
 
 // Takes a data buffer and a private key, to sign the data
 // with the private key and verify the data with the public key.
-pub fn sign_rsa_pkcs(databuf: &[u8], private_key: RsaPrivateKey) -> Result<Vec<u8>, Box<dyn Error>> {
+pub fn sign_rsa_pkcs(databuf: &[u8], private_key: RsaPrivateKey) -> Result<Vec<u8>> {
     let signing_key = pkcs1v15::SigningKey::<Sha256>::new(private_key);
 
     let signature = signing_key.sign(databuf);
@@ -33,14 +33,14 @@ pub fn sign_rsa_pkcs(databuf: &[u8], private_key: RsaPrivateKey) -> Result<Vec<u
 // with the public key.
 // As databuf is an in-memory buffer, the function has a limitation of max size
 // of the input data, like a few GiB. Going over that, it could result in OOM.
-pub fn verify_rsa_pkcs_buf(databuf: &[u8], signature: &[u8], public_key: RsaPublicKey) -> Result<(), Box<dyn Error>> {
+pub fn verify_rsa_pkcs_buf(databuf: &[u8], signature: &[u8], public_key: RsaPublicKey) -> Result<()> {
     // Equivalent of:
     //   openssl rsautl -verify -pubin -key |public_key_path|
     //   - in |sig_data| -out |out_hash_data|
 
     let verifying_key = pkcs1v15::VerifyingKey::<Sha256>::new(public_key);
 
-    Ok(verifying_key.verify(databuf, &pkcs1v15::Signature::try_from(signature).unwrap())?)
+    verifying_key.verify(databuf, &pkcs1v15::Signature::try_from(signature).unwrap()).context(format!("failed to verify signature ({:?})", signature))
 }
 
 // Takes a data buffer, signature and a public key, to verify the data
@@ -49,40 +49,40 @@ pub fn verify_rsa_pkcs_buf(databuf: &[u8], signature: &[u8], public_key: RsaPubl
 // buffer, so it does not have a limitation of max size of input data.
 // It relies on RSA PrehashVerifier.
 // TODO: consider migrating to RSA DigestVerifier.
-pub fn verify_rsa_pkcs_prehash(digestbuf: &[u8], signature: &[u8], public_key: RsaPublicKey) -> Result<(), Box<dyn Error>> {
+pub fn verify_rsa_pkcs_prehash(digestbuf: &[u8], signature: &[u8], public_key: RsaPublicKey) -> Result<()> {
     let verifying_key = pkcs1v15::VerifyingKey::<Sha256>::new(public_key);
 
-    Ok(verifying_key.verify_prehash(digestbuf, &pkcs1v15::Signature::try_from(signature).unwrap())?)
+    verifying_key.verify_prehash(digestbuf, &pkcs1v15::Signature::try_from(signature).unwrap()).context(format!("failed to verify_prehash signature ({:?})", signature))
 }
 
-pub fn get_private_key_pkcs_pem(private_key_path: &str, key_type: KeyType) -> RsaPrivateKey {
+pub fn get_private_key_pkcs_pem(private_key_path: &str, key_type: KeyType) -> Result<RsaPrivateKey> {
     let private_key_buf = fs::read_to_string(private_key_path).unwrap();
     let out_key = match key_type {
-        KeyType::KeyTypePkcs1 => RsaPrivateKey::from_pkcs1_pem(private_key_buf.as_str()).unwrap_or_else(|error| {
-            panic!("failed to parse PKCS1 PEM message: {:?}", error);
+        KeyType::KeyTypePkcs1 => RsaPrivateKey::from_pkcs1_pem(private_key_buf.as_str()).or_else(|error| {
+            bail!("failed to parse PKCS1 PEM message: {:?}", error);
         }),
-        KeyType::KeyTypePkcs8 => RsaPrivateKey::from_pkcs8_pem(private_key_buf.as_str()).unwrap_or_else(|error| {
-            panic!("failed to parse PKCS8 PEM message: {:?}", error);
+        KeyType::KeyTypePkcs8 => RsaPrivateKey::from_pkcs8_pem(private_key_buf.as_str()).or_else(|error| {
+            bail!("failed to parse PKCS8 PEM message: {:?}", error);
         }),
         KeyType::KeyTypeNone => {
-            panic!("invalid key type: {:?}", key_type);
+            bail!("invalid key type: {:?}", key_type);
         }
     };
 
     out_key
 }
 
-pub fn get_public_key_pkcs_pem(public_key_path: &str, key_type: KeyType) -> RsaPublicKey {
+pub fn get_public_key_pkcs_pem(public_key_path: &str, key_type: KeyType) -> Result<RsaPublicKey> {
     let public_key_buf = fs::read_to_string(public_key_path).unwrap();
     let out_key = match key_type {
-        KeyType::KeyTypePkcs1 => RsaPublicKey::from_pkcs1_pem(public_key_buf.as_str()).unwrap_or_else(|error| {
-            panic!("failed to parse PKCS1 PEM message: {:?}", error);
+        KeyType::KeyTypePkcs1 => RsaPublicKey::from_pkcs1_pem(public_key_buf.as_str()).or_else(|error| {
+            bail!("failed to parse PKCS1 PEM message: {:?}", error);
         }),
-        KeyType::KeyTypePkcs8 => RsaPublicKey::from_public_key_pem(public_key_buf.as_str()).unwrap_or_else(|error| {
-            panic!("failed to parse PKCS8 PEM message: {:?}", error);
+        KeyType::KeyTypePkcs8 => RsaPublicKey::from_public_key_pem(public_key_buf.as_str()).or_else(|error| {
+            bail!("failed to parse PKCS8 PEM message: {:?}", error);
         }),
         KeyType::KeyTypeNone => {
-            panic!("invalid key type: {:?}", key_type);
+            bail!("invalid key type: {:?}", key_type);
         }
     };
 
@@ -103,28 +103,36 @@ mod tests {
     #[test]
     fn test_verify_sig() {
         // PKCS1
-        let signature = sign_rsa_pkcs(TESTDATA.as_bytes(), get_private_key_pkcs_pem(PRIVKEY_PKCS1_PATH, KeyTypePkcs1)).unwrap_or_else(|error| {
+        let signature = sign_rsa_pkcs(
+            TESTDATA.as_bytes(),
+            get_private_key_pkcs_pem(PRIVKEY_PKCS1_PATH, KeyTypePkcs1).unwrap(),
+        )
+        .unwrap_or_else(|error| {
             panic!("failed to sign data: {:?}", error);
         });
 
         _ = verify_rsa_pkcs_buf(
             TESTDATA.as_bytes(),
             signature.as_slice(),
-            get_public_key_pkcs_pem(PUBKEY_PKCS1_PATH, KeyTypePkcs1),
+            get_public_key_pkcs_pem(PUBKEY_PKCS1_PATH, KeyTypePkcs1).unwrap(),
         )
         .unwrap_or_else(|error| {
             panic!("failed to verify data: {:?}", error);
         });
 
         // PKCS8
-        let signature = sign_rsa_pkcs(TESTDATA.as_bytes(), get_private_key_pkcs_pem(PRIVKEY_PKCS8_PATH, KeyTypePkcs8)).unwrap_or_else(|error| {
+        let signature = sign_rsa_pkcs(
+            TESTDATA.as_bytes(),
+            get_private_key_pkcs_pem(PRIVKEY_PKCS8_PATH, KeyTypePkcs8).unwrap(),
+        )
+        .unwrap_or_else(|error| {
             panic!("failed to sign data: {:?}", error);
         });
 
         _ = verify_rsa_pkcs_buf(
             TESTDATA.as_bytes(),
             signature.as_slice(),
-            get_public_key_pkcs_pem(PUBKEY_PKCS8_PATH, KeyTypePkcs8),
+            get_public_key_pkcs_pem(PUBKEY_PKCS8_PATH, KeyTypePkcs8).unwrap(),
         )
         .unwrap_or_else(|error| {
             panic!("failed to verify data: {:?}", error);


### PR DESCRIPTION
Add a new dependency of `anyhow` crate, to use flexible concrete error handling mechanism, instead of the native error types.

To follow error handling convention of anyhow, insert `.context` to add detailed message of error context when returning from functions.
In case of an immediate error exit, use a `bail!` macro.

Note, main functions and unit tests stay untouched if possible.

Fixes https://github.com/flatcar/ue-rs/issues/25