### PR TITLE
Change return types to Result in signature verification

### DIFF
--- a/src/bin/download_sysext.rs
+++ b/src/bin/download_sysext.rs
@@ -217,7 +217,7 @@ impl<'a> Package<'a> {
 
         // Parse signature data from sig blobs, data blobs, public key, and verify.
         match delta_update::parse_signature_data(&sigbytes, hdhashvec.as_slice(), pubkey_path) {
-            Some(_) => (),
+            Ok(_) => (),
             _ => {
                 self.status = PackageStatus::BadSignature;
                 bail!(

--- a/test/crau_verify.rs
+++ b/test/crau_verify.rs
@@ -70,7 +70,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Parse signature data from the signature containing data, version, special fields.
     let sigdata = match delta_update::parse_signature_data(&sigbytes, hdhashvec.as_slice(), PUBKEY_FILE) {
-        Some(data) => Box::leak(data),
+        Ok(data) => data,
         _ => return Err("unable to parse signature data".into()),
     };
 
@@ -78,7 +78,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Store signature into a file.
     let mut sigfile = fs::File::create(sigpath.clone())?;
-    let _ = sigfile.write_all(sigdata);
+    let _ = sigfile.write_all(sigdata.as_slice());
 
     println!("Wrote signature data into file {:?}", sigpath);
 


### PR DESCRIPTION
To deal with signature verification errors in a detailed way, let's change return type of `parse_signature_data` functions back to `Result`.

Iterate over signature slots to find a valid signature. If not found, return Error.

See also https://github.com/flatcar/ue-rs/issues/28