### PR TITLE
Remove clippy warnings

### DIFF
--- a/examples/response.rs
+++ b/examples/response.rs
@@ -5,7 +5,7 @@ use hard_xml::XmlRead;
 use omaha;
 
 #[rustfmt::skip]
-const RESPONSE_XML: &'static str =
+const RESPONSE_XML: &str =
 r#"<?xml version="1.0" encoding="UTF-8"?>
 <response protocol="3.0" server="nebraska">
   <daystart elapsed_seconds="0"/>
@@ -45,8 +45,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             println!("    package {}:", pkg.name);
 
             #[rustfmt::skip]
-            pkg.hash.as_ref()
-                .map(|h| println!("      sha1: {}", h));
+            if let Some(h) = pkg.hash.as_ref() {
+                println!("      sha1: {}", h);
+            };
 
             #[rustfmt::skip]
             let hash_sha256 = pkg.hash_sha256

--- a/omaha/src/hash_types.rs
+++ b/omaha/src/hash_types.rs
@@ -50,7 +50,7 @@ impl<T: HashAlgo> fmt::Debug for Hash<T> {
         let hash_hex = Hex::encode_to_string(self.0.as_ref())
             .map_err(|_| fmt::Error)?;
 
-        f.debug_tuple(&*tn).field(&hash_hex).finish()
+        f.debug_tuple(&tn).field(&hash_hex).finish()
     }
 }
 
@@ -72,10 +72,10 @@ impl<T: HashAlgo> str::FromStr for Hash<T> {
     }
 }
 
-impl<T: HashAlgo> Into<Vec<u8>> for Hash<T> {
-    fn into(self) -> Vec<u8> {
+impl<T: HashAlgo> From<Hash<T>> for Vec<u8> {
+    fn from(val: Hash<T>) -> Self {
         let mut vec = Vec::new();
-        vec.append(&mut self.0.as_ref().to_vec());
+        vec.append(&mut val.0.as_ref().to_vec());
         vec
     }
 }

--- a/omaha/src/response.rs
+++ b/omaha/src/response.rs
@@ -144,9 +144,8 @@ impl<'__input: 'a, 'a> hard_xml::XmlRead<'__input> for Manifest<'a> {
         reader.read_till_element_start("manifest")?;
 
         while let Some((k, v)) = reader.find_attribute()? {
-            match k {
-                "version" => __self_version = Some(v),
-                _ => ()
+            if k == "version" {
+                __self_version = Some(v);
             }
         }
 
@@ -169,7 +168,7 @@ impl<'__input: 'a, 'a> hard_xml::XmlRead<'__input> for Manifest<'a> {
                 "packages" => {
                     reader.read_till_element_start("packages")?;
 
-                    while let Some(_) = reader.find_attribute()? {}
+                    while (reader.find_attribute()?).is_some() {}
 
                     if let Token::ElementEnd { end: ElementEnd::Empty, .. }
                         = reader.next().unwrap()?
@@ -196,7 +195,7 @@ impl<'__input: 'a, 'a> hard_xml::XmlRead<'__input> for Manifest<'a> {
                 "actions" => {
                     reader.read_till_element_start("actions")?;
 
-                    while let Some(_) = reader.find_attribute()? {}
+                    while (reader.find_attribute()?).is_some() {}
 
                     if let Token::ElementEnd { end: ElementEnd::Empty, .. }
                         = reader.next().unwrap()?
@@ -227,7 +226,7 @@ impl<'__input: 'a, 'a> hard_xml::XmlRead<'__input> for Manifest<'a> {
             }
         }
 
-        return Ok(Manifest {
+        Ok(Manifest {
             version: __self_version
                 .ok_or(XmlError::MissingField {
                     name: "Manifest".to_owned(),
@@ -235,7 +234,7 @@ impl<'__input: 'a, 'a> hard_xml::XmlRead<'__input> for Manifest<'a> {
                 })?,
                 packages: __self_packages,
                 actions: __self_actions,
-        });
+        })
     }
 }
 #[derive(Debug)]
@@ -260,9 +259,8 @@ impl<'__input: 'a, 'a> hard_xml::XmlRead<'__input> for UpdateCheck<'a> {
         reader.read_till_element_start("updatecheck")?;
 
         while let Some((k, v)) = reader.find_attribute()? {
-            match k {
-                "status" => __self_status = Some(v),
-                _ => {}
+            if k == "status" {
+                __self_status = Some(v);
             }
         }
 
@@ -289,7 +287,7 @@ impl<'__input: 'a, 'a> hard_xml::XmlRead<'__input> for UpdateCheck<'a> {
                 "urls" => {
                     reader.read_till_element_start("urls")?;
 
-                    while let Some(_) = reader.find_attribute()? {}
+                    while (reader.find_attribute()?).is_some() {}
                     if let Token::ElementEnd { end: ElementEnd::Empty, .. }
                         = reader.next().unwrap()?
                     {
@@ -301,15 +299,11 @@ impl<'__input: 'a, 'a> hard_xml::XmlRead<'__input> for UpdateCheck<'a> {
                             "url" => {
                                 reader.read_till_element_start("url")?;
                                 while let Some((k, v)) = reader.find_attribute()? {
-                                    match k {
-                                        "codebase" => {
-                                            __self_urls.push(
-                                                Url::from_str(&v)
-                                                    .map_err(|e| XmlError::FromStr(e.into()))?,
-                                            )
-                                        }
-
-                                        _ => {}
+                                    if k == "codebase" {
+                                        __self_urls.push(
+                                            Url::from_str(&v)
+                                                .map_err(|e| XmlError::FromStr(e.into()))?,
+                                        )
                                     }
                                 }
 
@@ -337,7 +331,7 @@ impl<'__input: 'a, 'a> hard_xml::XmlRead<'__input> for UpdateCheck<'a> {
             }
         }
 
-        return Ok(UpdateCheck {
+        Ok(UpdateCheck {
             status: __self_status
                 .ok_or(XmlError::MissingField {
                     name: "UpdateCheck".to_owned(),
@@ -349,7 +343,7 @@ impl<'__input: 'a, 'a> hard_xml::XmlRead<'__input> for UpdateCheck<'a> {
                     name: "UpdateCheck".to_owned(),
                     field: "manifest".to_owned(),
                 })?,
-        });
+        })
     }
 }
 

--- a/src/bin/download_sysext.rs
+++ b/src/bin/download_sysext.rs
@@ -127,10 +127,10 @@ impl<'a> Package<'a> {
 
         if self.hash != calculated {
             self.status = PackageStatus::BadChecksum;
-            return false;
+            false
         } else {
             self.status = PackageStatus::Unverified;
-            return true;
+            true
         }
     }
 
@@ -311,7 +311,7 @@ impl Args {
         let mut builder = GlobSetBuilder::new();
 
         for m in &*self.image_match {
-            builder.add(Glob::new(&*m)?);
+            builder.add(Glob::new(m)?);
         }
 
         builder.build()

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 
 use anyhow::{Context, Result};
 use hard_xml::XmlWrite;
-use omaha;
 
 //
 // SERVER=https://public.update.flatcar-linux.net/v1/update/
@@ -13,13 +12,12 @@ use omaha;
 // FLATCAR_RELEASE_APPID={e96281a6-d1af-4bde-9a0a-97b76e56dc57}
 //
 
-const UPDATE_URL: &'static str = "https://public.update.flatcar-linux.net/v1/update/";
-const PROTOCOL_VERSION: &'static str = "3.0";
-// const UPDATER_VERSION_STR: &'static str = "update-engine-0.4.10";
-const UPDATER_VERSION_STR: &'static str = "ue-rs-0.0.0";
+const UPDATE_URL: &str = "https://public.update.flatcar-linux.net/v1/update/";
+const PROTOCOL_VERSION: &str = "3.0";
+const UPDATER_VERSION_STR: &str = "ue-rs-0.0.0";
 
-const OS_PLATFORM: &'static str = "CoreOS";
-const OS_VERSION: &'static str = "Chateau";
+const OS_PLATFORM: &str = "CoreOS";
+const OS_VERSION: &str = "Chateau";
 
 const APP_ID: omaha::Uuid = omaha::uuid!("{e96281a6-d1af-4bde-9a0a-97b76e56dc57}");
 
@@ -83,5 +81,5 @@ pub async fn perform<'a>(client: &reqwest::Client, parameters: Parameters<'a>) -
         .await
         .context("client post send({UPDATE_URL}) failed")?;
 
-    Ok(resp.text().await.context("failed to get response")?)
+    resp.text().await.context("failed to get response")
 }

--- a/test/crau_verify.rs
+++ b/test/crau_verify.rs
@@ -1,7 +1,6 @@
 use std::io::{BufReader, Write};
 use std::error::Error;
 use std::fs;
-use tempfile;
 
 use update_format_crau::delta_update;
 


### PR DESCRIPTION
Address issues reported by `cargo clippy`.

* Remove unnecessary `use omaha`.
* Remove `'static` for const strings.
* Use `Some(h)` instead of map().
* Remove `map(f)` on an Option value where f is a closure that returns unit type ().
* Deref would be done by auto-deref.
* Remove unneeded `return`.
* Use if instead of match in case of equility checks.
* Remove redundant pattern matching, use `is_some()`.
* Use `From<Hash<T>> for Vec<u8>` instead of `Into<Vec<u8>> for Hash<T>`.
* Remove unnecessary `Ok` and question mark.

Note: issues in `vendor/hard-xml*` are not touched.

Fixes https://github.com/flatcar/ue-rs/issues/32