### PR TITLE
Cargo.toml: Add release profile for smaller size and overflow checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,14 @@ members = [
 [[bin]]
 name = "crau_verify"
 path = "test/crau_verify.rs"
+
+[profile.release]
+# We do some offset calculations for extraction and
+# the generated protobuf code does even more, let's
+# be cautious
+overflow-checks = true
+# Reduce binary size by stripping debug symbols
+strip = true
+# Reduce binary size by using one codegen unit for similar gains as thin LTO
+# (which we had problem with when cross-compiling)
+codegen-units = 1


### PR DESCRIPTION
The release binary should be as small as possible without impact. Since this is new code we also want the release binary to still have overflow checks instead of silently eating them.
Add a release profile that strips the debug symbols, uses one codegen unit to get similar gains as thin LTO (which we seem to have cross- compiling problems with), and enable overflow checks.
