### PR TITLE
download: Make progress reporting opt-in

### DIFF
--- a/examples/download_test.rs
+++ b/examples/download_test.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("fetching {}...", url);
 
     let data = Vec::new();
-    let res = download_and_hash(&client, url, data).await?;
+    let res = download_and_hash(&client, url, data, false).await?;
 
     println!("hash: {}", res.hash);
 

--- a/examples/full_test.rs
+++ b/examples/full_test.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         //       std::io::BufWriter wrapping an std::fs::File is probably the right choice.
         //       std::io::sink() is basically just /dev/null
         let data = std::io::sink();
-        let res = ue_rs::download_and_hash(&client, url.clone(), data).await.context(format!("download_and_hash({url:?}) failed"))?;
+        let res = ue_rs::download_and_hash(&client, url.clone(), data, false).await.context(format!("download_and_hash({url:?}) failed"))?;
 
         println!("\texpected sha256:   {}", expected_sha256);
         println!("\tcalculated sha256: {}", res.hash);

--- a/src/download.rs
+++ b/src/download.rs
@@ -57,7 +57,7 @@ pub fn hash_on_disk_sha256(path: &Path, maxlen: Option<usize>) -> Result<omaha::
     Ok(omaha::Hash::from_bytes(hasher.finalize().into()))
 }
 
-pub async fn download_and_hash<U, W>(client: &reqwest::Client, url: U, mut data: W) -> Result<DownloadResult<W>>
+pub async fn download_and_hash<U, W>(client: &reqwest::Client, url: U, mut data: W, print_progress: bool) -> Result<DownloadResult<W>>
 where
     U: reqwest::IntoUrl + Clone,
     W: io::Write,
@@ -100,14 +100,15 @@ where
         hasher.update(&chunk);
         data.write_all(&chunk).context("failed to write_all chunk")?;
 
-        // TODO: better way to report progress?
-        print!(
-            "\rread {}/{} ({:3}%)",
-            bytes_read,
-            bytes_to_read,
-            ((bytes_read as f32 / bytes_to_read as f32) * 100.0f32).floor()
-        );
-        io::stdout().flush().context("failed to flush stdout")?;
+        if print_progress {
+            print!(
+                "\rread {}/{} ({:3}%)",
+                bytes_read,
+                bytes_to_read,
+                ((bytes_read as f32 / bytes_to_read as f32) * 100.0f32).floor()
+            );
+            io::stdout().flush().context("failed to flush stdout")?;
+        }
     }
 
     data.flush().context("failed to flush data")?;


### PR DESCRIPTION
For scripting the current progress report is too verbose. Add a flag to opt-in.

## How to use

Add `--print-progress` if wanted

## Testing done

Default behavior is no output. With `--print-progress` the report works as before.

Fixes https://github.com/flatcar/ue-rs/issues/38