### PR TITLE
download_sysext: HTTP client timeout and retry

### DIFF
--- a/src/bin/download_sysext.rs
+++ b/src/bin/download_sysext.rs
@@ -7,6 +7,7 @@ use std::io;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::time::Duration;
 
 #[macro_use]
 extern crate log;
@@ -318,6 +319,9 @@ impl Args {
     }
 }
 
+const HTTP_CONN_TIMEOUT: u64 = 20;
+const DOWNLOAD_TIMEOUT: u64 = 3600;
+
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
@@ -337,7 +341,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     fs::create_dir_all(&temp_dir)?;
 
     // The default policy of reqwest Client supports max 10 attempts on HTTP redirect.
-    let client = Client::builder().redirect(Policy::default()).build()?;
+    let client = Client::builder().connect_timeout(Duration::from_secs(HTTP_CONN_TIMEOUT)).timeout(Duration::from_secs(DOWNLOAD_TIMEOUT)).redirect(Policy::default()).build()?;
 
     // If input_xml exists, simply read it.
     // If not, try to read from payload_url.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,7 @@ pub use download::DownloadResult;
 pub use download::download_and_hash;
 pub use download::hash_on_disk_sha256;
 
+mod util;
+pub use util::retry_loop;
+
 pub mod request;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,25 @@
+use core::time::Duration;
+use std::thread::sleep;
+
+const RETRY_INTERVAL_MSEC: u64 = 1000;
+
+pub fn retry_loop<F, T, E>(mut func: F, max_tries: u32) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+{
+    let mut tries = 0;
+
+    loop {
+        match func() {
+            ok @ Ok(_) => return ok,
+            err @ Err(_) => {
+                tries += 1;
+
+                if tries >= max_tries {
+                    return err;
+                }
+                sleep(Duration::from_millis(RETRY_INTERVAL_MSEC));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Set the default timeout to 20 seconds, so HTTP client can abort after that timeout.

If HTTP client fails to download, retry to download once in 1000 msec, up to 20 times.

Fixes https://github.com/flatcar/ue-rs/issues/15