### PR TITLE
Switch to reqwest::blocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
+name = "futures-io"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+
+[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,9 +369,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1303,19 +1312,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "socket2 0.5.3",
- "tokio-macros",
  "windows-sys",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.31",
 ]
 
 [[package]]
@@ -1396,7 +1393,6 @@ dependencies = [
  "reqwest",
  "sha2",
  "tempfile",
- "tokio",
  "update-format-crau",
  "url",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,9 @@ env_logger = "0.10"
 globset = "0.4"
 log = "0.4"
 protobuf = "3.2.0"
-reqwest = "0.11"
+reqwest = { version = "0.11", features = ["blocking"] }
 sha2 = "0.10"
 tempfile = "3.8.1"
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 url = "2"
 uuid = "1.2"
 

--- a/examples/download_test.rs
+++ b/examples/download_test.rs
@@ -4,16 +4,17 @@ use std::str::FromStr;
 
 use ue_rs::download_and_hash;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
-    let client = reqwest::Client::new();
+fn main() -> Result<(), Box<dyn Error>> {
+    let client = reqwest::blocking::Client::new();
 
     let url = Url::from_str(std::env::args().nth(1).expect("missing URL (second argument)").as_str())?;
 
     println!("fetching {}...", url);
 
-    let data = Vec::new();
-    let res = download_and_hash(&client, url, data, false).await?;
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path().join("tmpfile");
+    let res = download_and_hash(&client, url, &path, false)?;
+    tempdir.close()?;
 
     println!("hash: {}", res.hash);
 

--- a/examples/request.rs
+++ b/examples/request.rs
@@ -5,9 +5,8 @@ use anyhow::Context;
 
 use ue_rs::request;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
-    let client = reqwest::Client::new();
+fn main() -> Result<(), Box<dyn Error>> {
+    let client = reqwest::blocking::Client::new();
 
     const APP_VERSION_DEFAULT: &str = "3340.0.0+nightly-20220823-2100";
     const MACHINE_ID_DEFAULT: &str = "abce671d61774703ac7be60715220bfe";
@@ -20,7 +19,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         track: Cow::Borrowed(TRACK_DEFAULT),
     };
 
-    let response = request::perform(&client, parameters).await.context(format!(
+    let response = request::perform(&client, parameters).context(format!(
         "perform({APP_VERSION_DEFAULT}, {MACHINE_ID_DEFAULT}, {TRACK_DEFAULT}) failed"
     ))?;
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -28,7 +28,7 @@ pub struct Parameters<'a> {
     pub machine_id: Cow<'a, str>,
 }
 
-pub async fn perform<'a>(client: &reqwest::Client, parameters: Parameters<'a>) -> Result<String> {
+pub fn perform<'a>(client: &reqwest::blocking::Client, parameters: Parameters<'a>) -> Result<String> {
     let req_body = {
         let r = omaha::Request {
             protocol_version: Cow::Borrowed(PROTOCOL_VERSION),
@@ -78,8 +78,7 @@ pub async fn perform<'a>(client: &reqwest::Client, parameters: Parameters<'a>) -
     let resp = client.post(UPDATE_URL)
         .body(req_body)
         .send()
-        .await
         .context("client post send({UPDATE_URL}) failed")?;
 
-    resp.text().await.context("failed to get response")
+    resp.text().context("failed to get response")
 }


### PR DESCRIPTION
Seems to work :)

## How to use

Agree if we want to use this 

## Testing done

Downloading with a direct URL and with the XML works. I also checked that the download is done to disk and there is no copy in RAM (/usr/bin/time -v shows the Maximum resident set size to be 24 MB for the full Flatcar update payload which is 370 MB).
