### PR TITLE
Use explicit offsets for reading and writing

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result, bail};
-use std::io::{BufReader, Read, Seek, SeekFrom};
+use std::io::{BufReader, Read};
 use std::fs::File;
 use std::path::Path;
 use log::info;
@@ -39,7 +39,6 @@ pub fn hash_on_disk_sha256(path: &Path, maxlen: Option<usize>) -> Result<omaha::
     let mut freader = BufReader::new(file);
     let mut chunklen: usize;
 
-    freader.seek(SeekFrom::Start(0)).context("failed to seek(0)".to_string())?;
     while maxlen_to_read > 0 {
         if maxlen_to_read < CHUNKLEN {
             chunklen = maxlen_to_read;


### PR DESCRIPTION
- download: Remove unused seek to 0
    
    The file is freshly opened and already at offset 0.
- Use explicit offsets for reading and writing
    
    Currently the order in which the functions are called matters because
    they advance the offset. Some had seeks but not all.
    Use explicit read and write offsets to make the code more robust. Also,
    we have to make use of the start_block to calculate the destination even
    if we didn't ran into a problem yet because the way we generate the
    payload was giving the order we happened to write out.


## How to use


## Testing done

The generic payload and the sysext payload extracts as usual.
