### PR TITLE
Check Omaha sha1 hash if available and Verify checksum after download, with retry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,3 +34,8 @@ jobs:
         with:
           command: test
           args: --workspace
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ct-codecs",
+ "digest",
  "hard-xml",
+ "sha1",
+ "sha2",
  "url",
  "uuid",
 ]
@@ -1143,10 +1146,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.7"
+name = "sha1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/examples/download_test.rs
+++ b/examples/download_test.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let res = download_and_hash(&client, url, &path, false)?;
     tempdir.close()?;
 
-    println!("hash: {}", res.hash);
+    println!("hash: {}", res.hash_sha256);
 
     Ok(())
 }

--- a/examples/download_test.rs
+++ b/examples/download_test.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path().join("tmpfile");
-    let res = download_and_hash(&client, url, &path, false)?;
+    let res = download_and_hash(&client, url, &path, None, None, false)?;
     tempdir.close()?;
 
     println!("hash: {}", res.hash_sha256);

--- a/examples/full_test.rs
+++ b/examples/full_test.rs
@@ -80,7 +80,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         let tempdir = tempfile::tempdir()?;
         let path = tempdir.path().join("tmpfile");
-        let res = ue_rs::download_and_hash(&client, url.clone(), &path, false).context(format!("download_and_hash({url:?}) failed"))?;
+        let res = ue_rs::download_and_hash(&client, url.clone(), &path, Some(expected_sha256.clone()), None, false).context(format!("download_and_hash({url:?}) failed"))?;
         tempdir.close()?;
 
         println!("\texpected sha256:   {}", expected_sha256);

--- a/examples/full_test.rs
+++ b/examples/full_test.rs
@@ -84,8 +84,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         tempdir.close()?;
 
         println!("\texpected sha256:   {}", expected_sha256);
-        println!("\tcalculated sha256: {}", res.hash);
-        println!("\tsha256 match?      {}", expected_sha256 == res.hash);
+        println!("\tcalculated sha256: {}", res.hash_sha256);
+        println!("\tsha256 match?      {}", expected_sha256 == res.hash_sha256);
     }
 
     Ok(())

--- a/omaha/Cargo.toml
+++ b/omaha/Cargo.toml
@@ -10,6 +10,9 @@ uuid = "1.2"
 ct-codecs = "1"
 url = "2"
 anyhow = "1.0.75"
+sha2 = "0.10.8"
+sha1 = "0.10.6"
+digest = "0.10.7"
 
 [dependencies.hard-xml]
 path = "../vendor/hard-xml"

--- a/omaha/src/hash_types.rs
+++ b/omaha/src/hash_types.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::str;
 
+use sha2::Digest;
+
 use anyhow::{Error as CodecError, anyhow};
 
 #[rustfmt::skip]
@@ -22,24 +24,61 @@ pub trait HashAlgo {
     const HASH_NAME: &'static str;
 
     type Output: AsRef<[u8]> + AsMut<[u8]> + Default + Sized + Eq;
+
+    fn hasher() -> impl digest::DynDigest;
+    fn from_boxed(s: Box<[u8]>) -> Self::Output;
 }
 
 impl HashAlgo for Sha1 {
     const HASH_NAME: &'static str = "Sha1";
     type Output = [u8; 20];
+
+    fn hasher() -> impl digest::DynDigest {
+        sha1::Sha1::new()
+    }
+
+    fn from_boxed(s: Box<[u8]>) -> Self::Output {
+        let mut v = s.into_vec();
+        v.resize(Self::Output::default().len(), 0);
+        let boxed_array: Box<Self::Output> = match v.into_boxed_slice().try_into() {
+            Ok(a) => a,
+            Err(e) => {
+                println!("Unexpected length {}", e.len());
+                Box::new(Self::Output::default())
+            }
+        };
+        *boxed_array
+    }
 }
 
 impl HashAlgo for Sha256 {
     const HASH_NAME: &'static str = "Sha256";
     type Output = [u8; 32];
+
+    fn hasher() -> impl digest::DynDigest {
+        sha2::Sha256::new()
+    }
+
+    fn from_boxed(s: Box<[u8]>) -> Self::Output {
+        let mut v = s.into_vec();
+        v.resize(Self::Output::default().len(), 0);
+        let boxed_array: Box<Self::Output> = match v.into_boxed_slice().try_into() {
+            Ok(a) => a,
+            Err(e) => {
+                println!("Unexpected length {}", e.len());
+                Box::new(Self::Output::default())
+            }
+        };
+        *boxed_array
+    }
 }
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct Hash<T: HashAlgo>(T::Output);
 
 impl<T: HashAlgo> Hash<T> {
-    pub fn from_bytes(digest: T::Output) -> Self {
-        Self(digest)
+    pub fn from_bytes(digest: Box<[u8]>) -> Self {
+        Self(T::from_boxed(digest))
     }
 }
 

--- a/omaha/src/hash_types.rs
+++ b/omaha/src/hash_types.rs
@@ -44,6 +44,7 @@ impl HashAlgo for Sha1 {
             Ok(a) => a,
             Err(e) => {
                 println!("Unexpected length {}", e.len());
+                #[allow(clippy::box_default)]
                 Box::new(Self::Output::default())
             }
         };
@@ -66,6 +67,7 @@ impl HashAlgo for Sha256 {
             Ok(a) => a,
             Err(e) => {
                 println!("Unexpected length {}", e.len());
+                #[allow(clippy::box_default)]
                 Box::new(Self::Output::default())
             }
         };

--- a/src/bin/download_sysext.rs
+++ b/src/bin/download_sysext.rs
@@ -177,7 +177,7 @@ impl<'a> Package<'a> {
         };
 
         let datahash = self.hash_on_disk::<omaha::Sha256>(datablobspath.as_path(), None).context(format!("failed to hash_on_disk path ({:?})", datablobspath.display()))?;
-        if datahash != omaha::Hash::from_bytes(pinfo_hash.as_slice()[..].try_into().unwrap_or_default()) {
+        if datahash != omaha::Hash::from_bytes(pinfo_hash.as_slice()[..].into()) {
             bail!(
                 "mismatch of data hash ({:?}) with new_partition_info hash ({:?})",
                 datahash,
@@ -226,7 +226,7 @@ fn get_pkgs_to_download<'a>(resp: &'a omaha::Response, glob_set: &GlobSet)
             // TODO: multiple URLs per package
             //       not sure if nebraska sends us more than one right now but i suppose this is
             //       for mirrors?
-            let Some(Ok(url)) = app.update_check.urls.get(0)
+            let Some(Ok(url)) = app.update_check.urls.first()
                 .map(|u| u.join(&pkg.name)) else {
                 warn!("can't get url for package `{}`, skipping", pkg.name);
                 continue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 mod download;
 pub use download::DownloadResult;
 pub use download::download_and_hash;
-pub use download::hash_on_disk_sha256;
+pub use download::hash_on_disk;
 
 mod util;
 pub use util::retry_loop;

--- a/src/request.rs
+++ b/src/request.rs
@@ -28,7 +28,7 @@ pub struct Parameters<'a> {
     pub machine_id: Cow<'a, str>,
 }
 
-pub fn perform<'a>(client: &reqwest::blocking::Client, parameters: Parameters<'a>) -> Result<String> {
+pub fn perform(client: &reqwest::blocking::Client, parameters: Parameters<'_>) -> Result<String> {
     let req_body = {
         let r = omaha::Request {
             protocol_version: Cow::Borrowed(PROTOCOL_VERSION),

--- a/test/crau_verify.rs
+++ b/test/crau_verify.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Get length of header and data, including header and manifest.
     let header_data_length = delta_update::get_header_data_length(&header, &delta_archive_manifest).context("failed to get header data length")?;
-    let hdhash = ue_rs::hash_on_disk_sha256(headerdatapath.as_path(), Some(header_data_length))?;
+    let hdhash = ue_rs::hash_on_disk::<omaha::Sha256>(headerdatapath.as_path(), Some(header_data_length))?;
     let hdhashvec: Vec<u8> = hdhash.clone().into();
 
     // Get length of header and data

--- a/vendor/hard-xml-derive/src/lib.rs
+++ b/vendor/hard-xml-derive/src/lib.rs
@@ -1,5 +1,7 @@
 #![recursion_limit = "256"]
 
+#![allow(clippy::all)]
+
 extern crate proc_macro;
 
 mod attrs;

--- a/vendor/hard-xml/src/lib.rs
+++ b/vendor/hard-xml/src/lib.rs
@@ -333,6 +333,7 @@
 //!     Root { attr: true }
 //! );
 //! ```
+#![allow(clippy::all)]
 
 #[cfg(feature = "log")]
 mod log;


### PR DESCRIPTION
- Check Omaha sha1 hash if available
    Old Nebraska servers were missing the newly introduced sha256 attribute and might only serve paylads with the regular sha1 attribute set. The generic payload is also just using the regular sha1 attribute because at that time a different extension was used which holds the sha256 checksum for the generic payload.
Support the regular Omaha sha1 hash for use with old Nebraska servers. This makes it also easy to test with the generic payload.

- Verify checksum after download, with retry
    
    The self.verify_checksum(...) call's return value wasn't checked in the
    package download call. Even if we do it there we should rather move it
    into the retry loop and make it explicit whether we expect certain
    checksums or not.
    Check the checksum after the download, and also retry when it
    mismatches.



## How to use

Fixes https://github.com/flatcar/ue-rs/issues/31

I think this is the last piece to start using it in Flatcar.

## Testing done

```
RUST_LOG=debug target/release/download_sysext -p ~/kinvolk/scripts/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-au-key/files/official-v2.pub.pem -m oem-azure.gz -o /var/tmp/outdir/ -u https://update.release.flatcar-linux.net/amd64-usr/3815.0.0/oem-azure.gz -v
RUST_LOG=debug target/release/download_sysext -p ~/kinvolk/scripts/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-au-key/files/official-v2.pub.pem -m oem-azure.gz -o /var/tmp/outdir/ -i /var/tmp/beta-response -v
RUST_LOG=debug target/release/download_sysext -p ~/kinvolk/scripts/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-au-key/files/official-v2.pub.pem -m flatcar_production_update.gz -o /var/tmp/outdir/ -i /var/tmp/beta-response -v
```