### PR TITLE
.github: cargo clippy with --deny warnings option

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,4 +38,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace
+          args: --workspace -- --deny warnings


### PR DESCRIPTION
To make the CI correctly work when running cargo clippy, an additional option `-- --deny warnings` is needed.
Without that, cargo clippy would always succeed, so CI is not able to check its result.
