### PR TITLE
Cargo.toml: remove unnecessary crates bzip2, protobuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,13 +1421,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "argh",
- "bzip2",
  "env_logger",
  "globset",
  "hard-xml",
  "log",
  "omaha",
- "protobuf",
  "reqwest",
  "sha2",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,7 @@ strip = true
 # Reduce binary size by using one codegen unit for similar gains as thin LTO
 # (which we had problem with when cross-compiling)
 codegen-units = 1
+
+# cargo-machete shows false positive of uuid, which is actually needed.
+[package.metadata.cargo-machete]
+ignored = ["uuid"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,9 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.75"
 argh = "0.1"
-bzip2 = "0.4.4"
 env_logger = "0.10"
 globset = "0.4"
 log = "0.4"
-protobuf = "3.2.0"
 reqwest = { version = "0.11", features = ["blocking"] }
 sha2 = "0.10"
 tempfile = "3.8.1"


### PR DESCRIPTION
Remove unnecssary crates, `bzip2` and `protobuf`. Detected by `cargo-machete`.

For some reason cargo-machete shows false positive of uuid, which is actually needed for building ue-rs. Exlude uuid from machete.

