### PR TITLE
.github: rename default branch from trunk to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,10 +2,10 @@ name: "Run CI"
 on:
   push:
     branches:
-      - trunk
+      - main
   pull_request:
     branches:
-      - trunk
+      - main
 
 jobs:
   build-test:


### PR DESCRIPTION
Rename the default branch from `trunk` to `main`, following the general Flatcar repo settings guideline.