### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,7 @@
 name: "Run CI"
+permissions:
+  contents: read
+  pull-requests: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/flatcar/ue-rs/security/code-scanning/1](https://github.com/flatcar/ue-rs/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read-only operations (e.g., checking out code, running tests), the minimal required permission is `contents: read`. This ensures that the `GITHUB_TOKEN` used in the workflow has restricted access, reducing the risk of unintended or malicious actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
