### PR TITLE
*: fix clippy issues with Rust 1.88+.

### DIFF
--- a/omaha/src/response.rs
+++ b/omaha/src/response.rs
@@ -67,7 +67,7 @@ impl FromStr for ActionEvent {
             "postinstall" => ActionEvent::PostInstall,
             "update" => ActionEvent::Update,
 
-            _ => return Err(format!("unknown success action \"{}\"", s)),
+            _ => return Err(format!("unknown success action \"{s}\"")),
         })
     }
 }
@@ -98,7 +98,7 @@ impl FromStr for SuccessAction {
             "exitsilently" => SuccessAction::ExitSilently,
             "exitsilentlyonlaunchcmd" => SuccessAction::ExitSilentlyOnLaunchCommand,
 
-            _ => return Err(format!("unknown success action \"{}\"", s)),
+            _ => return Err(format!("unknown success action \"{s}\"")),
         })
     }
 }

--- a/src/bin/download_sysext.rs
+++ b/src/bin/download_sysext.rs
@@ -118,7 +118,7 @@ impl Package<'_> {
         ) {
             Ok(ok) => ok,
             Err(err) => {
-                error!("Downloading failed with error {}", err);
+                error!("Downloading failed with error {err}");
                 self.status = PackageStatus::DownloadFailed;
                 bail!("unable to download data(url {})", self.url);
             }
@@ -130,10 +130,10 @@ impl Package<'_> {
 
     fn verify_checksum(&mut self, calculated_sha256: omaha::Hash<omaha::Sha256>, calculated_sha1: omaha::Hash<omaha::Sha1>) -> bool {
         debug!("    expected sha256:   {:?}", self.hash_sha256);
-        debug!("    calculated sha256: {}", calculated_sha256);
+        debug!("    calculated sha256: {calculated_sha256}");
         debug!("    sha256 match?      {}", self.hash_sha256 == Some(calculated_sha256.clone()));
         debug!("    expected sha1:   {:?}", self.hash_sha1);
-        debug!("    calculated sha1: {}", calculated_sha1);
+        debug!("    calculated sha1: {calculated_sha1}");
         debug!("    sha1 match?      {}", self.hash_sha1 == Some(calculated_sha1.clone()));
 
         if self.hash_sha256.is_some() && self.hash_sha256 != Some(calculated_sha256.clone()) || self.hash_sha1.is_some() && self.hash_sha1 != Some(calculated_sha1.clone()) {
@@ -198,7 +198,7 @@ impl Package<'_> {
             }
         };
 
-        println!("Parsed and verified signature data from file {:?}", from_path);
+        println!("Parsed and verified signature data from file {from_path:?}");
 
         self.status = PackageStatus::Verified;
         Ok(datablobspath)
@@ -255,7 +255,7 @@ where
     U: reqwest::IntoUrl + From<U> + std::clone::Clone + std::fmt::Debug,
     Url: From<U>,
 {
-    let r = ue_rs::download_and_hash(client, input_url.clone(), path, None, None).context(format!("unable to download data(url {:?})", input_url))?;
+    let r = ue_rs::download_and_hash(client, input_url.clone(), path, None, None).context(format!("unable to download data(url {input_url:?})"))?;
 
     Ok(Package {
         name: Cow::Borrowed(path.file_name().unwrap_or(OsStr::new("fakepackage")).to_str().unwrap_or("fakepackage")),
@@ -280,7 +280,7 @@ fn do_download_verify(pkg: &mut Package<'_>, output_filename: Option<String>, ou
     let datablobspath = pkg.verify_signature_on_disk(&pkg_unverified, pubkey_file).context(format!("unable to verify signature \"{}\"", pkg.name))?;
 
     // write extracted data into the final data.
-    debug!("data blobs written into file {:?}", pkg_verified);
+    debug!("data blobs written into file {pkg_verified:?}");
     fs::rename(datablobspath, pkg_verified)?;
 
     Ok(())
@@ -339,7 +339,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
     let args: Args = argh::from_env();
-    println!("{:?}", args);
+    println!("{args:?}");
 
     if args.payload_url.is_none() && !args.take_first_match && args.target_filename.is_some() {
         return Err("--target-filename can only be specified with --take-first-match".into());
@@ -411,7 +411,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let response_text = res_local.ok_or(anyhow!("failed to get response text"))?;
-    debug!("response_text: {:?}", response_text);
+    debug!("response_text: {response_text:?}");
 
     ////
     // parse response
@@ -420,7 +420,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut pkgs_to_dl = get_pkgs_to_download(&resp, &glob_set)?;
 
-    debug!("pkgs:\n\t{:#?}", pkgs_to_dl);
+    debug!("pkgs:\n\t{pkgs_to_dl:#?}");
     debug!("");
 
     ////

--- a/src/download.rs
+++ b/src/download.rs
@@ -49,7 +49,7 @@ pub fn hash_on_disk<T: omaha::HashAlgo>(path: &Path, maxlen: Option<usize>) -> R
 
         let mut databuf = vec![0u8; chunklen];
 
-        freader.read_exact(&mut databuf).context(format!("failed to read_exact(chunklen {:?})", chunklen))?;
+        freader.read_exact(&mut databuf).context(format!("failed to read_exact(chunklen {chunklen:?})"))?;
 
         maxlen_to_read -= chunklen;
 
@@ -97,11 +97,11 @@ where
     let calculated_sha256 = hash_on_disk::<omaha::Sha256>(path, None)?;
     let calculated_sha1 = hash_on_disk::<omaha::Sha1>(path, None)?;
 
-    debug!("    expected sha256:   {:?}", expected_sha256);
-    debug!("    calculated sha256: {}", calculated_sha256);
+    debug!("    expected sha256:   {expected_sha256:?}");
+    debug!("    calculated sha256: {calculated_sha256}");
     debug!("    sha256 match?      {}", expected_sha256 == Some(calculated_sha256.clone()));
-    debug!("    expected sha1:   {:?}", expected_sha1);
-    debug!("    calculated sha1: {}", calculated_sha1);
+    debug!("    expected sha1:   {expected_sha1:?}");
+    debug!("    calculated sha1: {calculated_sha1}");
     debug!("    sha1 match?      {}", expected_sha1 == Some(calculated_sha1.clone()));
 
     if expected_sha256.is_some() && expected_sha256 != Some(calculated_sha256.clone()) {

--- a/src/request.rs
+++ b/src/request.rs
@@ -71,7 +71,7 @@ pub fn perform(client: &reqwest::blocking::Client, parameters: Parameters<'_>) -
     };
 
     // TODO: remove
-    println!("request body:\n\t{}", req_body);
+    println!("request body:\n\t{req_body}");
     println!();
 
     #[rustfmt::skip]

--- a/test/crau_verify.rs
+++ b/test/crau_verify.rs
@@ -57,21 +57,17 @@ fn main() -> Result<(), Box<dyn Error>> {
     let sigdata = match delta_update::parse_signature_data(&sigbytes, hdhashvec.as_slice(), PUBKEY_FILE) {
         Ok(data) => data,
         _ => {
-            return Err(format!(
-                "unable to parse and verify signature, sigbytes ({:?}), hdhash ({:?}), pubkey_path ({:?})",
-                sigbytes, hdhash, PUBKEY_FILE,
-            )
-            .into());
+            return Err(format!("unable to parse and verify signature, sigbytes ({sigbytes:?}), hdhash ({hdhash:?}), pubkey_path ({PUBKEY_FILE:?})",).into());
         }
     };
 
-    println!("Parsed signature data from file {:?}", srcpath);
+    println!("Parsed signature data from file {srcpath:?}");
 
     // Store signature into a file.
     let mut sigfile = fs::File::create(sigpath.clone())?;
     let _ = sigfile.write_all(sigdata.as_slice());
 
-    println!("Wrote signature data into file {:?}", sigpath);
+    println!("Wrote signature data into file {sigpath:?}");
 
     Ok(())
 }

--- a/update-format-crau/src/verify_sig.rs
+++ b/update-format-crau/src/verify_sig.rs
@@ -45,7 +45,7 @@ pub fn verify_rsa_pkcs_buf(databuf: &[u8], signature: &[u8], public_key: RsaPubl
             databuf,
             &pkcs1v15::Signature::try_from(signature).context(anyhow!("unable to convert signature into pkcs1v15::Signature"))?,
         )
-        .context(format!("failed to verify signature ({:?})", signature))
+        .context(format!("failed to verify signature ({signature:?})"))
 }
 
 // Takes a data buffer, signature and a public key, to verify the data
@@ -62,20 +62,20 @@ pub fn verify_rsa_pkcs_prehash(digestbuf: &[u8], signature: &[u8], public_key: R
             digestbuf,
             &pkcs1v15::Signature::try_from(signature).context(anyhow!("unable to convert signature into pkcs1v15::Signature"))?,
         )
-        .context(format!("failed to verify_prehash signature ({:?})", signature))
+        .context(format!("failed to verify_prehash signature ({signature:?})"))
 }
 
 pub fn get_private_key_pkcs_pem(private_key_path: &str, key_type: KeyType) -> Result<RsaPrivateKey> {
-    let private_key_buf = fs::read_to_string(private_key_path).context(format!("failed to read private key from path {:?}", private_key_path))?;
+    let private_key_buf = fs::read_to_string(private_key_path).context(format!("failed to read private key from path {private_key_path:?}"))?;
     let out_key = match key_type {
         KeyType::KeyTypePkcs1 => RsaPrivateKey::from_pkcs1_pem(private_key_buf.as_str()).or_else(|error| {
-            bail!("failed to parse PKCS1 PEM message: {:?}", error);
+            bail!("failed to parse PKCS1 PEM message: {error:?}");
         }),
         KeyType::KeyTypePkcs8 => RsaPrivateKey::from_pkcs8_pem(private_key_buf.as_str()).or_else(|error| {
-            bail!("failed to parse PKCS8 PEM message: {:?}", error);
+            bail!("failed to parse PKCS8 PEM message: {error:?}");
         }),
         KeyType::KeyTypeNone => {
-            bail!("invalid key type: {:?}", key_type);
+            bail!("invalid key type: {key_type:?}");
         }
     };
 
@@ -83,16 +83,16 @@ pub fn get_private_key_pkcs_pem(private_key_path: &str, key_type: KeyType) -> Re
 }
 
 pub fn get_public_key_pkcs_pem(public_key_path: &str, key_type: KeyType) -> Result<RsaPublicKey> {
-    let public_key_buf = fs::read_to_string(public_key_path).context(format!("failed to read public key from path {:?}", public_key_path))?;
+    let public_key_buf = fs::read_to_string(public_key_path).context(format!("failed to read public key from path {public_key_path:?}"))?;
     let out_key = match key_type {
         KeyType::KeyTypePkcs1 => RsaPublicKey::from_pkcs1_pem(public_key_buf.as_str()).or_else(|error| {
-            bail!("failed to parse PKCS1 PEM message: {:?}", error);
+            bail!("failed to parse PKCS1 PEM message: {error:?}");
         }),
         KeyType::KeyTypePkcs8 => RsaPublicKey::from_public_key_pem(public_key_buf.as_str()).or_else(|error| {
-            bail!("failed to parse PKCS8 PEM message: {:?}", error);
+            bail!("failed to parse PKCS8 PEM message: {error:?}");
         }),
         KeyType::KeyTypeNone => {
-            bail!("invalid key type: {:?}", key_type);
+            bail!("invalid key type: {key_type:?}");
         }
     };
 


### PR DESCRIPTION
Starting from Rust 1.88, clippy prints out warnings in case of uninlined format arguments in format strings.
Fix them to unblock CI.

```
error: variables can be used directly in the `format!` string
Error:   --> omaha/src/response.rs:70:29
   |
70 |             _ => return Err(format!("unknown success action \"{}\"", s)),
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
   = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::uninlined_format_args)]`
help: change this to
   |
70 -             _ => return Err(format!("unknown success action \"{}\"", s)),
70 +             _ => return Err(format!("unknown success action \"{s}\"")),
```

Fixes https://github.com/flatcar/ue-rs/issues/70