### PR TITLE
test: fix clippy issue with tempfile::TempDir::into_path()

### DIFF
--- a/test/crau_verify.rs
+++ b/test/crau_verify.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Extract signature from header.
     let sigbytes = delta_update::get_signatures_bytes(&upfile, &header, &mut delta_archive_manifest)?;
 
-    let tmpdir = tempfile::tempdir()?.into_path();
+    let tmpdir = tempfile::tempdir()?.keep();
     fs::create_dir_all(tmpdir.clone())?;
     let headerdatapath = tmpdir.join("ue_header_data");
 


### PR DESCRIPTION
Fix a clippy warning with Rust 1.88+.

```
warning: use of deprecated method `tempfile::TempDir::into_path`: use TempDir::keep()
  --> test/crau_verify.rs:41:39
   |
41 |     let tmpdir = tempfile::tempdir()?.into_path();
   |                                       ^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: `ue-rs` (bin "crau_verify") generated 1 warning
```
