### PR TITLE
Util Module Improvements

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -24,12 +24,12 @@ use std::thread::sleep;
 ///
 /// let result = retry_loop(|| read_possibly_extant_file("might_exist.txt"), 3);
 /// ```
-const RETRY_INTERVAL_MSEC: u64 = 1000;
-
 pub fn retry_loop<F, T, E>(mut func: F, max_tries: u32) -> Result<T, E>
 where
     F: FnMut() -> Result<T, E>,
 {
+    const RETRY_INTERVAL_MSEC: u64 = 1000;
+
     let mut tries = 0;
 
     loop {

--- a/src/util.rs
+++ b/src/util.rs
@@ -28,21 +28,14 @@ pub fn retry_loop<F, T, E>(mut func: F, max_tries: u32) -> Result<T, E>
 where
     F: FnMut() -> Result<T, E>,
 {
-    const RETRY_INTERVAL_MSEC: u64 = 1000;
+    const RETRY_INTERVAL: Duration = Duration::from_millis(1000);
 
-    let mut tries = 0;
-
-    loop {
+    for _ in 0..max_tries - 1 {
         match func() {
-            ok @ Ok(_) => return ok,
-            err @ Err(_) => {
-                tries += 1;
-
-                if tries >= max_tries {
-                    return err;
-                }
-                sleep(Duration::from_millis(RETRY_INTERVAL_MSEC));
-            }
+            Ok(ret) => return Ok(ret),
+            Err(_) => sleep(RETRY_INTERVAL),
         }
     }
+
+    func()
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,29 @@
 use core::time::Duration;
 use std::thread::sleep;
 
+/// Retries the supplied function until it returns `Ok` or the supplied maximum
+/// retry limit is reached.
+///
+/// # Examples
+///
+/// ```rust
+/// use std::{fs, io};
+/// use ue_rs::retry_loop;
+/// use std::sync::atomic::{AtomicUsize, Ordering};
+/// use std::path::Path;
+///
+/// fn read_possibly_extant_file<P: AsRef<Path>>(path: P) -> io::Result<String> {
+///     let file_path = Path::new(path.as_ref());
+///
+///     if file_path.exists() {
+///         fs::read_to_string(file_path)
+///     } else {
+///         Err(io::Error::new(io::ErrorKind::NotFound, io::Error::last_os_error()))
+///     }
+/// }
+///
+/// let result = retry_loop(|| read_possibly_extant_file("might_exist.txt"), 3);
+/// ```
 const RETRY_INTERVAL_MSEC: u64 = 1000;
 
 pub fn retry_loop<F, T, E>(mut func: F, max_tries: u32) -> Result<T, E>


### PR DESCRIPTION
# Improvements to the util module

There is currently only one function in the `util` module: `retry_loop()`. This PR improves this function (and therefore module) in that it:

- Adds unit tests for `retry_loop()` as per #77. 
- Adds a docstring with a usage example as per #78.
- Rewrites the function slightly to be more readable and rusty.

