### PR TITLE
download: Fix bug of pkg_verified path extension

### DIFF
--- a/src/bin/download_sysext.rs
+++ b/src/bin/download_sysext.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use argh::FromArgs;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
-use ue_rs::{TARGET_FILENAME_DEFAULT, DownloadVerify};
+use ue_rs::DownloadVerify;
 
 #[derive(FromArgs, Debug)]
 /// Parse an update-engine Omaha XML response to extract sysext images, then download and verify
@@ -102,9 +102,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let glob_set = args.image_match_glob_set()?;
 
     DownloadVerify::new(args.output_dir, args.pubkey_file, args.take_first_match, glob_set)
-        .target_filename(args.target_filename.unwrap_or(TARGET_FILENAME_DEFAULT.into()))
+        .target_filename(args.target_filename)
         .input_xml(input_xml.unwrap_or_default())
-        .payload_url(payload_url.clone())
+        .payload_url(Some(payload_url.clone()))
         .run()?;
 
     Ok(())

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -212,7 +212,8 @@ fn do_download_verify(pkg: &mut Package<'_>, output_filename: Option<String>, ou
     // Unverified payload is stored in e.g. "output_dir/.unverified/oem.gz".
     // Verified payload is stored in e.g. "output_dir/oem.raw".
     let pkg_unverified = unverified_dir.join(&*pkg.name);
-    let pkg_verified = output_dir.join(output_filename.as_ref().map(OsStr::new).unwrap_or(pkg_unverified.with_extension("raw").file_name().unwrap_or_default()));
+    let mut pkg_verified = output_dir.join(output_filename.as_ref().map(OsStr::new).unwrap_or(pkg_unverified.with_extension("raw").file_name().unwrap_or_default()));
+    pkg_verified.set_extension("raw");
 
     let datablobspath = pkg.verify_signature_on_disk(&pkg_unverified, pubkey_file).context(format!("unable to verify signature \"{}\"", pkg.name))?;
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -24,9 +24,6 @@ const DOWNLOAD_TIMEOUT: u64 = 3600;
 const HTTP_CONN_TIMEOUT: u64 = 20;
 const MAX_DOWNLOAD_RETRY: u32 = 20;
 
-pub const TARGET_FILENAME_DEFAULT: &str = "oem-azure.gz";
-pub const PAYLOAD_URL_DEFAULT: &str = "https://update.release.flatcar-linux.net/amd64-usr/current/oem-azure.gz";
-
 const UNVERFIED_SUFFIX: &str = ".unverified";
 const TMP_SUFFIX: &str = ".tmp";
 
@@ -247,8 +244,8 @@ impl DownloadVerify {
         }
     }
 
-    pub fn target_filename(mut self, param_target_filename: String) -> Self {
-        self.target_filename = Some(param_target_filename);
+    pub fn target_filename(mut self, param_target_filename: Option<String>) -> Self {
+        self.target_filename = param_target_filename;
         self
     }
 
@@ -257,8 +254,8 @@ impl DownloadVerify {
         self
     }
 
-    pub fn payload_url(mut self, param_payload_url: String) -> Self {
-        self.payload_url = Some(param_payload_url);
+    pub fn payload_url(mut self, param_payload_url: Option<String>) -> Self {
+        self.payload_url = param_payload_url;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 mod download;
-pub use download::TARGET_FILENAME_DEFAULT;
-pub use download::PAYLOAD_URL_DEFAULT;
 pub use download::{DownloadResult, DownloadVerify};
 pub use download::download_and_hash;
 pub use download::hash_on_disk;


### PR DESCRIPTION
Before PR https://github.com/flatcar/ue-rs/pull/87, `target_filename` was almost always `None`, which had hidden an issue of setting `pkg_verified`. In case of `target_filename` being a valid String, for example `oem-azure.gz`, `pkg_verified` ended up having an extension `.gz`, which is not expected.

Now that the PR was merged, DownloadVerify module gets created with `.target_filename(args.target_filename.unwrap_or(TARGET_FILENAME_DEFAULT.into()))`, where `TARGET_FILENAME_DEFAULT` is with `.gz` extension. That uncovered the hidden issue.

Fix that with explicitly setting extension `.raw` for both a valid String and None for the input string.

Since the target filename could vary for many update payload types and OEMs, it does not make sense to set a default filename to a specific target file name. Remove `TARGET_FILENAME_DEFAULT` and `PAYLOAD_URL_DEFAULT`.

Let `target_filename()` & `payload_url()` take `Option<String>` parameter, to be able to pass either `Some(String)` or `None`, to fix a wrong target_filename issue.


## Testing done

Local test passed, Jenkins CI will run soon.

