### PR TITLE
Remove `anyhow` Dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
 name = "argh"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,7 +1577,6 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 name = "ue-rs"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "argh",
  "env_logger",
  "globset",
@@ -1608,7 +1601,6 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 name = "update-format-crau"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "bzip2",
  "log",
  "protobuf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.75"
 argh = "0.1"
 env_logger = "0.10"
 globset = "0.4"

--- a/examples/request.rs
+++ b/examples/request.rs
@@ -1,8 +1,6 @@
 use std::error::Error;
 use std::borrow::Cow;
 
-use anyhow::Context;
-
 use ue_rs::request;
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -19,9 +17,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         track: Cow::Borrowed(TRACK_DEFAULT),
     };
 
-    let response = request::perform(&client, parameters).context(format!(
-        "perform({APP_VERSION_DEFAULT}, {MACHINE_ID_DEFAULT}, {TRACK_DEFAULT}) failed"
-    ))?;
+    let response = request::perform(&client, parameters)?;
 
     println!("response:\n\t{:#?}", response);
 

--- a/examples/response.rs
+++ b/examples/response.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 
-use anyhow::Context;
 use hard_xml::XmlRead;
 use omaha;
 
@@ -30,7 +29,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("{}", RESPONSE_XML);
     println!();
 
-    let resp = omaha::Response::from_str(RESPONSE_XML).context("failed to create response")?;
+    // TODO: fine for a small example but shouldnt be encouraged
+    let resp = omaha::Response::from_str(RESPONSE_XML).unwrap();
 
     println!("{:#?}", resp);
     println!();
@@ -70,7 +70,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             for url in &app.update_check.urls {
                 println!(
                     "        {}",
-                    url.join(&pkg.name).context(format!("failed to join URL with {:?}", pkg.name))?
+                    // TODO: fine for a small example but shouldnt be encouraged
+                    url.join(&pkg.name).unwrap()
                 );
             }
 

--- a/src/bin/download_sysext.rs
+++ b/src/bin/download_sysext.rs
@@ -6,7 +6,6 @@ use std::path::Path;
 #[macro_use]
 extern crate log;
 
-use anyhow::Result;
 use argh::FromArgs;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -9,15 +9,16 @@ use std::path::Path;
 use std::str::FromStr;
 use std::time::Duration;
 
-use anyhow::{Context, Result, anyhow, bail};
 use globset::GlobSet;
 use hard_xml::XmlRead;
 use log::{debug, info, warn};
-use reqwest::{StatusCode, blocking::Client, redirect::Policy};
+use reqwest::{blocking::Client, redirect::Policy};
 use url::Url;
 
 use crate::{Package, PackageStatus};
 use omaha::{Sha1Digest, Sha256Digest};
+use crate::error::Error;
+use crate::Result;
 
 const DOWNLOAD_TIMEOUT: u64 = 3600;
 const HTTP_CONN_TIMEOUT: u64 = 20;
@@ -33,9 +34,9 @@ pub struct DownloadResult {
 }
 
 pub fn hash_on_disk<T: omaha::Hasher>(path: &Path, maxlen: Option<usize>) -> Result<T::Output> {
-    let file = File::open(path).context(format!("File::open({:?})", path))?;
+    let file = File::open(path).map_err(Error::OpenFile)?;
 
-    let filelen = file.metadata().context(format!("failed to get metadata of {:?}", path))?.len() as usize;
+    let filelen = file.metadata().map_err(Error::GetFileMetadata)?.len() as usize;
 
     let mut maxlen_to_read: usize = match maxlen {
         Some(len) => {
@@ -61,7 +62,7 @@ pub fn hash_on_disk<T: omaha::Hasher>(path: &Path, maxlen: Option<usize>) -> Res
             databuf.truncate(maxlen_to_read);
         }
 
-        freader.read_exact(&mut databuf).context(format!("failed to read_exact(chunklen {:?})", databuf.len()))?;
+        freader.read_exact(&mut databuf).map_err(Error::ReadFromFile)?;
 
         maxlen_to_read -= databuf.len();
 
@@ -78,10 +79,7 @@ where
 {
     let client_url = url.clone();
 
-    #[rustfmt::skip]
-    let mut res = client.get(url.clone())
-        .send()
-        .context(format!("client get & send{:?} failed ", client_url.as_str()))?;
+    let mut res = client.get(url.clone()).send().map_err(|err| Error::SendGetRequest(url.into(), err))?;
 
     // Redirect was already handled at this point, so there is no need to touch
     // response or url again. Simply print info and continue.
@@ -89,22 +87,15 @@ where
         info!("redirected to URL {:?}", res.url());
     }
 
-    // Return immediately on download failure on the client side.
-    let status = res.status();
-
-    if !status.is_success() {
-        match status {
-            StatusCode::FORBIDDEN | StatusCode::NOT_FOUND => {
-                bail!("cannnot fetch remotely with status code {:?}", status);
-            }
-            _ => bail!("general failure with status code {:?}", status),
-        }
+    match res.status() {
+        status if !status.is_success() => return Err(Error::GetRequestFailed(status)),
+        _ => {}
     }
 
     println!("writing to {}", path.display());
 
-    let mut file = File::create(path).context(format!("failed to create path ({:?})", path.display()))?;
-    res.copy_to(&mut file)?;
+    let mut file = File::create(path).map_err(Error::CreateFile)?;
+    res.copy_to(&mut file).map_err(Error::CopyRequestBodyToFile)?;
 
     let calculated_sha256 = hash_on_disk::<omaha::Sha256>(path, None)?;
     let calculated_sha1 = hash_on_disk::<omaha::Sha1>(path, None)?;
@@ -116,11 +107,14 @@ where
     debug!("    calculated sha1: {calculated_sha1:?}");
     debug!("    sha1 match?      {}", expected_sha1 == Some(calculated_sha1));
 
-    if expected_sha256.is_some() && expected_sha256 != Some(calculated_sha256) {
-        bail!("checksum mismatch for sha256");
+    match expected_sha256 {
+        Some(exp) if exp != calculated_sha256 => return Err(Error::Sha256ChecksumMismatch(exp, calculated_sha256)),
+        _ => {}
     }
-    if expected_sha1.is_some() && expected_sha1 != Some(calculated_sha1) {
-        bail!("checksum mismatch for sha1");
+
+    match expected_sha1 {
+        Some(exp) if exp != calculated_sha1 => return Err(Error::Sha1ChecksumMismatch(exp, calculated_sha1)),
+        _ => {}
     }
 
     Ok(DownloadResult {
@@ -189,13 +183,13 @@ where
     U: reqwest::IntoUrl + From<U> + std::clone::Clone + std::fmt::Debug,
     Url: From<U>,
 {
-    let r = download_and_hash(client, input_url.clone(), path, None, None).context(format!("unable to download data(url {input_url:?})"))?;
+    let r = download_and_hash(client, input_url.clone(), path, None, None)?;
 
     Ok(Package {
         name: Cow::Borrowed(path.file_name().unwrap_or(OsStr::new("fakepackage")).to_str().unwrap_or("fakepackage")),
         hash_sha256: Some(r.hash_sha256),
         hash_sha1: Some(r.hash_sha1),
-        size: r.data.metadata().context(format!("failed to get metadata, path ({:?})", path.display()))?.len() as usize,
+        size: r.data.metadata().map_err(Error::GetFileMetadata)?.len() as usize,
         url: input_url.into(),
         status: PackageStatus::Unverified,
     })
@@ -204,7 +198,7 @@ where
 fn do_download_verify(pkg: &mut Package<'_>, output_filename: Option<String>, output_dir: &Path, unverified_dir: &Path, pubkey_file: &str, client: &Client) -> Result<()> {
     pkg.check_download(unverified_dir)?;
 
-    pkg.download(unverified_dir, client).context(format!("unable to download \"{:?}\"", pkg.name))?;
+    pkg.download(unverified_dir, client)?;
 
     // Unverified payload is stored in e.g. "output_dir/.unverified/oem.gz".
     // Verified payload is stored in e.g. "output_dir/oem.raw".
@@ -212,11 +206,11 @@ fn do_download_verify(pkg: &mut Package<'_>, output_filename: Option<String>, ou
     let mut pkg_verified = output_dir.join(output_filename.as_ref().map(OsStr::new).unwrap_or(pkg_unverified.with_extension("raw").file_name().unwrap_or_default()));
     pkg_verified.set_extension("raw");
 
-    let datablobspath = pkg.verify_signature_on_disk(&pkg_unverified, pubkey_file).context(format!("unable to verify signature \"{}\"", pkg.name))?;
+    let datablobspath = pkg.verify_signature_on_disk(&pkg_unverified, pubkey_file)?;
 
     // write extracted data into the final data.
     debug!("data blobs written into file {pkg_verified:?}");
-    fs::rename(datablobspath, pkg_verified)?;
+    fs::rename(datablobspath, pkg_verified).map_err(Error::RenameFile)?;
 
     Ok(())
 }
@@ -264,8 +258,8 @@ impl DownloadVerify {
 
         let unverified_dir = output_dir.join(UNVERFIED_SUFFIX);
         let temp_dir = output_dir.join(TMP_SUFFIX);
-        fs::create_dir_all(&unverified_dir)?;
-        fs::create_dir_all(&temp_dir)?;
+        fs::create_dir_all(&unverified_dir).map_err(Error::CreateDirectory)?;
+        fs::create_dir_all(&temp_dir).map_err(Error::CreateDirectory)?;
 
         // The default policy of reqwest Client supports max 10 attempts on HTTP redirect.
         let client = Client::builder()
@@ -273,18 +267,19 @@ impl DownloadVerify {
             .connect_timeout(Duration::from_secs(HTTP_CONN_TIMEOUT))
             .timeout(Duration::from_secs(DOWNLOAD_TIMEOUT))
             .redirect(Policy::default())
-            .build()?;
+            .build()
+            .map_err(Error::BuildClient)?;
 
         if self.payload_url.is_some() {
             let url = self.payload_url.clone().unwrap();
-            let u = Url::parse(&url)?;
-            let fname = u.path_segments().ok_or(anyhow!("failed to get path segments, url ({:?})", u))?.next_back().ok_or(anyhow!("failed to get path segments, url ({:?})", u))?;
+            let u = Url::parse(&url).map_err(Error::ParseUrl)?;
+            let fname = u.path_segments().ok_or(Error::InvalidBaseUrl(u.clone()))?.next_back().ok_or(Error::EmptyUrlIterator)?;
             let mut pkg_fake: Package;
 
             let temp_payload_path = unverified_dir.join(fname);
             pkg_fake = fetch_url_to_file(
                 &temp_payload_path,
-                Url::from_str(url.as_str()).context(anyhow!("failed to convert into url ({:?})", self.payload_url))?,
+                Url::from_str(url.as_str()).map_err(Error::ParseUrl)?,
                 &client,
             )?;
             do_download_verify(
@@ -303,7 +298,7 @@ impl DownloadVerify {
         ////
         // parse response
         ////
-        let resp = omaha::Response::from_str(&self.input_xml)?;
+        let resp = omaha::Response::from_str(&self.input_xml).map_err(Error::InvalidHashDigestString)?;
 
         let mut pkgs_to_dl = get_pkgs_to_download(&resp, &self.glob_set)?;
 
@@ -329,7 +324,7 @@ impl DownloadVerify {
         }
 
         // clean up data
-        fs::remove_dir_all(temp_dir)?;
+        fs::remove_dir_all(temp_dir).map_err(Error::RemoveDirectory)?;
 
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,68 @@
+use std::fmt::Debug;
+use std::path::PathBuf;
+use url::Url;
+
+#[derive(Debug)]
+pub enum Error {
+    OpenFile(std::io::Error),
+    GetFileMetadata(std::io::Error),
+    ReadFromFile(std::io::Error),
+    SendGetRequest(Url, reqwest::Error),
+    GetRequestFailed(reqwest::StatusCode),
+    CreateFile(std::io::Error),
+    CopyRequestBodyToFile(reqwest::Error),
+    Sha256ChecksumMismatch(omaha::Sha256Digest, omaha::Sha256Digest),
+    Sha1ChecksumMismatch(omaha::Sha1Digest, omaha::Sha1Digest),
+    DeltaUpdate(update_format_crau::delta_update::Error),
+    InvalidParentPath(PathBuf),
+    MissingPartitionHash,
+    RenameFile(std::io::Error),
+    CreateDirectory(std::io::Error),
+    BuildClient(reqwest::Error),
+    ParseUrl(url::ParseError),
+    InvalidBaseUrl(Url),
+    EmptyUrlIterator,
+    RemoveDirectory(std::io::Error),
+    InvalidHashDigestString(hard_xml::XmlError),
+    PostRequestFailed(reqwest::Error),
+    GetResponseBodyText(reqwest::Error),
+    XmlRequestToString(hard_xml::XmlError),
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::OpenFile(err) => write!(f, "failed to open file: {err}"),
+            Error::GetFileMetadata(err) => write!(f, "failed to get file metadata: {err}"),
+            Error::ReadFromFile(err) => write!(f, "failed to read file: {err}"),
+            Error::SendGetRequest(url, err) => write!(f, "failed to send GET request to {url}: {err}"),
+            Error::GetRequestFailed(status) => write!(f, "GET request returned status code {status}"),
+            Error::CreateFile(err) => write!(f, "failed to create file: {err}"),
+            Error::CopyRequestBodyToFile(err) => write!(f, "failed to copy request body to file: {err}"),
+            Error::Sha256ChecksumMismatch(exp, got) => write!(f, "SHA256 checksum mismatch: expected {exp:?}, got {got:?}"),
+            Error::Sha1ChecksumMismatch(exp, got) => write!(f, "SHA1 checksum mismatch: expected {exp:?}, got {got:?}"),
+            Error::DeltaUpdate(err) => write!(f, "failed to read delta update header: {err}"),
+            Error::InvalidParentPath(path) => write!(f, "invalid parent path: {path:?}"),
+            Error::MissingPartitionHash => write!(f, "missing partition hash"),
+            Error::RenameFile(err) => write!(f, "failed to rename file: {err}"),
+            Error::CreateDirectory(err) => write!(f, "failed to create directory: {err}"),
+            Error::BuildClient(err) => write!(f, "failed to build client: {err}"),
+            Error::ParseUrl(url) => write!(f, "failed to parse URL: {url}"),
+            Error::InvalidBaseUrl(url) => write!(f, "invalid base URL: {url}"),
+            Error::EmptyUrlIterator => write!(f, "empty URL iterator"),
+            Error::RemoveDirectory(err) => write!(f, "failed to remove directory: {err}"),
+            Error::InvalidHashDigestString(err) => write!(f, "invalid hash digest: {err}"),
+            Error::PostRequestFailed(err) => write!(f, "POST request failed: {err}"),
+            Error::GetResponseBodyText(err) => write!(f, "failed to get response body text: {err}"),
+            Error::XmlRequestToString(err) => write!(f, "xml request to string: {err}"),
+        }
+    }
+}
+
+impl From<update_format_crau::delta_update::Error> for Error {
+    fn from(err: update_format_crau::delta_update::Error) -> Self {
+        Error::DeltaUpdate(err)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,7 @@ pub use download::package::PackageStatus;
 mod util;
 pub use util::retry_loop;
 
+mod error;
 pub mod request;
+
+pub type Result<T> = std::result::Result<T, error::Error>;

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 
-use anyhow::{Context, Result};
 use hard_xml::XmlWrite;
+use crate::error::Error;
+use crate::Result;
 
 //
 // SERVER=https://public.update.flatcar-linux.net/v1/update/
@@ -67,18 +68,14 @@ pub fn perform(client: &reqwest::blocking::Client, parameters: Parameters<'_>) -
             ],
         };
 
-        r.to_string().context("failed to convert to string")?
+        r.to_string().map_err(Error::XmlRequestToString)?
     };
 
     // TODO: remove
     println!("request body:\n\t{req_body}");
     println!();
 
-    #[rustfmt::skip]
-    let resp = client.post(UPDATE_URL)
-        .body(req_body)
-        .send()
-        .context("client post send({UPDATE_URL}) failed")?;
+    let resp = client.post(UPDATE_URL).body(req_body).send().map_err(Error::PostRequestFailed)?;
 
-    resp.text().context("failed to get response")
+    resp.text().map_err(Error::GetResponseBodyText)
 }

--- a/test/crau_verify.rs
+++ b/test/crau_verify.rs
@@ -4,7 +4,6 @@ use std::fs;
 
 use update_format_crau::delta_update;
 
-use anyhow::Context;
 use argh::FromArgs;
 
 const PUBKEY_FILE: &str = "../src/testdata/public_key_test_pkcs8.pem";
@@ -43,7 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let headerdatapath = tmpdir.join("ue_header_data");
 
     // Get length of header and data, including header and manifest.
-    let header_data_length = delta_update::get_header_data_length(&header, &delta_archive_manifest).context("failed to get header data length")?;
+    let header_data_length = delta_update::get_header_data_length(&header, &delta_archive_manifest)?;
     let hdhash = ue_rs::hash_on_disk::<omaha::Sha256>(headerdatapath.as_path(), Some(header_data_length))?;
     let hdhashvec: Vec<u8> = hdhash.into();
 

--- a/update-format-crau/Cargo.toml
+++ b/update-format-crau/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.75"
 bzip2 = "0.4.4"
 log = "0.4.19"
 protobuf = "3"

--- a/update-format-crau/src/delta_update/error.rs
+++ b/update-format-crau/src/delta_update/error.rs
@@ -1,0 +1,72 @@
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub enum Error {
+    ReadHeaderMagic(std::io::Error),
+    BadHeaderMagic([u8; 4]),
+    ReadFileFormatVersion(std::io::Error),
+    UnsupportedFileFormatVersion(u64),
+    ReadManifestSize(std::io::Error),
+    ReadManifestBytes(std::io::Error),
+    ParseManifest(protobuf::Error),
+    ReadSignature(std::io::Error),
+    MissingSignatureOffset,
+    MissingSignatureSize,
+    MissingSignatureOffsetAndSize,
+    InvalidParentPath(PathBuf),
+    CreateDirectory(std::io::Error),
+    CreateFile(std::io::Error),
+    MissingDataOffset,
+    MissingDataLength,
+    IncorrectNumExtents(usize),
+    MissingStartBlock,
+    ReadData(std::io::Error),
+    MissingPartitionType,
+    UnpackBzip2(std::io::Error, u64),
+    CopyUnpackedData(std::io::Error, u64),
+    CopyPlainData(std::io::Error, u64),
+    FlushFile(std::io::Error, u64),
+    ParseSignatures(protobuf::Error),
+    NoValidSignature,
+    EmptySignature,
+    GetPkcs8PemPubKey(crate::verify_sig::Error),
+    VerifyPkcsSignature(crate::verify_sig::Error),
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::ReadHeaderMagic(err) => write!(f, "failed to read header magic: {err}"),
+            Error::BadHeaderMagic(magic) => write!(f, "bad header magic: {magic:?}"),
+            Error::ReadFileFormatVersion(err) => write!(f, "failed to read file format version: {err}"),
+            Error::UnsupportedFileFormatVersion(version) => write!(f, "unsupported file format version: {version}"),
+            Error::ReadManifestSize(err) => write!(f, "failed to read manifest size: {err}"),
+            Error::ReadManifestBytes(err) => write!(f, "failed to read manifest bytes: {err}"),
+            Error::ParseManifest(err) => write!(f, "failed to parse manifest: {err}"),
+            Error::ReadSignature(err) => write!(f, "failed to read signature: {err}"),
+            Error::MissingSignatureOffset => write!(f, "file header missing signature offset"),
+            Error::MissingSignatureSize => write!(f, "file header missing signature size"),
+            Error::MissingSignatureOffsetAndSize => write!(f, "file header missing signature offset and size"),
+            Error::InvalidParentPath(path) => write!(f, "invalid parent path: {path:?}"),
+            Error::CreateDirectory(err) => write!(f, "failed to create directory: {err}"),
+            Error::CreateFile(err) => write!(f, "failed to create file: {err}"),
+            Error::MissingDataOffset => write!(f, "install operation missing data offset"),
+            Error::MissingDataLength => write!(f, "install operation missing data length"),
+            Error::IncorrectNumExtents(num) => write!(f, "incorrect number of extents: expected 1, got {num}"),
+            Error::MissingStartBlock => write!(f, "extent missing start block"),
+            Error::ReadData(err) => write!(f, "failed to read data: {err}"),
+            Error::MissingPartitionType => write!(f, "install operation missing partition type"),
+            Error::UnpackBzip2(err, offset) => write!(f, "failed to unpack bzip2 at offset {offset}: {err}"),
+            Error::CopyUnpackedData(err, offset) => write!(f, "failed to copy unpacked data at offset {offset}: {err}"),
+            Error::CopyPlainData(err, offset) => write!(f, "failed to copy plaintext at offset {offset}: {err}"),
+            Error::FlushFile(err, offset) => write!(f, "failed to flush file at offset {offset}: {err}"),
+            Error::ParseSignatures(err) => write!(f, "failed to parse signatures: {err}"),
+            Error::NoValidSignature => write!(f, "failed to find a valid signature"),
+            Error::EmptySignature => write!(f, "empty signature"),
+            Error::GetPkcs8PemPubKey(err) => write!(f, "failed to get PKCS8 PEM public key: {err}"),
+            Error::VerifyPkcsSignature(err) => write!(f, "failed to verify PKCS signature: {err}"),
+        }
+    }
+}

--- a/update-format-crau/src/verify_sig/error.rs
+++ b/update-format-crau/src/verify_sig/error.rs
@@ -1,0 +1,30 @@
+#[derive(Debug)]
+pub enum Error {
+    DatabufNotSignedCorrectly,
+    InvalidPkcs1v15Signature(rsa::signature::Error),
+    CouldNotVerifySignature(rsa::signature::Error),
+    ReadPrivateKey(std::io::Error),
+    DeserialisePkcs1(rsa::pkcs1::Error),
+    DeserialisePkcs8(rsa::pkcs8::Error),
+    InvalidPrivateKeyType,
+    ReadPublicKey(std::io::Error),
+    DecodePublicKey(rsa::pkcs8::spki::Error),
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::DatabufNotSignedCorrectly => write!(f, "databuf was not signed correctly"),
+            Error::InvalidPkcs1v15Signature(err) => write!(f, "invalid pkcs1v15 signature: {err}"),
+            Error::CouldNotVerifySignature(err) => write!(f, "failed to verify signature: {err}"),
+            Error::ReadPrivateKey(err) => write!(f, "failed to read private key: {err}"),
+            Error::DeserialisePkcs1(err) => write!(f, "failed to deserialise PKCS1 PEM: {err}"),
+            Error::DeserialisePkcs8(err) => write!(f, "failed to deserialise PKCS8 PEM: {err}"),
+            Error::InvalidPrivateKeyType => write!(f, "invalid private key type"),
+            Error::ReadPublicKey(err) => write!(f, "failed to read public key: {err}"),
+            Error::DecodePublicKey(err) => write!(f, "failed to decode public key: {err}"),
+        }
+    }
+}


### PR DESCRIPTION
# Description

- I don't think that `anyhow` is ever necessary, and never useful beyong rapid prototyping, and thus has no place in a fully fledged project/library.
- Remove `anyhow` dependency from all crates and modules.
- They have been replaced with custom `Error` and `Result` types. The aim was to place these in a new crate-scoped `error.rs` file, however where there were modules with too large an amonut of errors, the modules have been converted to directory-style modules with an `error.rs` of their own. For example `a.rs` becomes `a/mod.rs` and `a/error.rs`.
- Partial completion of the goal of #89.

# Testing

- All existing testing still passes so no regression.
- No adhoc testing done.

# Notes 

- The textual error messages written for each `Error` enum variant in the `std::fmt::Display` impls was either suggested by Intellij, or written based off the original `.context()` and `bail()` calls. However I am open to them being changed.
- I made very slight changes where appropariate to make errors easier to bubble-up but otherwise make no logical changes (although I admit there were places I saw that definitely should have some attention; but that is not the purpose of this PR).
- Some potentially erroring function calls in files in `examples/` have just been replaced by `unwrap()` calls. I don't think its necessarily important to show users of such code to handle their own errors. 